### PR TITLE
Backport of GR-52940: Fix reported values in GCHeapSummary JFR event

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCHeapSummaryEvent.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCHeapSummaryEvent.java
@@ -55,11 +55,12 @@ class JfrGCHeapSummaryEvent {
             JfrNativeEventWriter.putLong(data, gcWhen.getId());
 
             // VirtualSpace
-            JfrNativeEventWriter.putLong(data, 0L); // start
-            JfrNativeEventWriter.putLong(data, 0L); // committedEnd
+            JfrNativeEventWriter.putLong(data, -1); // start
+            JfrNativeEventWriter.putLong(data, -1); // committedEnd
             JfrNativeEventWriter.putLong(data, committedSize.rawValue());
-            JfrNativeEventWriter.putLong(data, 0L); // reservedEnd
-            JfrNativeEventWriter.putLong(data, 0L); // reservedSize
+            JfrNativeEventWriter.putLong(data, -1); // reservedEnd
+            // Reserved heap size matches committed size
+            JfrNativeEventWriter.putLong(data, committedSize.rawValue()); // reservedSize
 
             JfrNativeEventWriter.putLong(data, heapUsed.rawValue());
             JfrNativeEventWriter.endSmallEvent(data);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/AbstractJfrTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/AbstractJfrTest.java
@@ -41,6 +41,7 @@ import java.util.function.BooleanSupplier;
 
 import org.graalvm.nativeimage.ImageInfo;
 import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeProxyCreation;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -54,6 +55,7 @@ import com.oracle.svm.util.ModuleSupport;
 import jdk.jfr.Configuration;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
+import jdk.jfr.Unsigned;
 
 /** Base class for JFR unit tests. */
 public abstract class AbstractJfrTest {
@@ -195,5 +197,17 @@ class JfrTestFeature implements Feature {
          * com.oracle.svm.test.jfr.utils.poolparsers.ClassConstantPoolParser.parse
          */
         ModuleSupport.accessPackagesToClass(ModuleSupport.Access.OPEN, JfrTestFeature.class, false, "jdk.internal.vm.compiler", "org.graalvm.compiler.serviceprovider");
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        /*
+         * Register proxies for event data assertion
+         *
+         * Unsigned added to be able to query RecordedObject.getLong() method, and this method
+         * checks if the value returned has the jdk.jfr.Unsigned. The jfr layer in HotSpot creates a
+         * proxy to query this information.
+         */
+        RuntimeProxyCreation.register(Unsigned.class);
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCHeapSummaryEvent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCHeapSummaryEvent.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import jdk.jfr.consumer.RecordedObject;
 import org.junit.Test;
 
 import com.oracle.svm.core.jfr.JfrEvent;
@@ -49,5 +50,16 @@ public class TestGCHeapSummaryEvent extends JfrRecordingTest {
 
     private static void validateEvents(List<RecordedEvent> events) {
         assertTrue(events.size() > 0);
+        for (RecordedEvent event : events) {
+            RecordedObject heapSpace = event.getValue("heapSpace");
+            assertTrue(heapSpace.getLong("start") == -1);
+            assertTrue(heapSpace.getLong("committedEnd") == -1);
+            assertTrue(heapSpace.getLong("reservedEnd") == -1);
+            assertTrue(heapSpace.getLong("committedSize") > 0);
+            assertTrue(heapSpace.getLong("reservedSize") >= heapSpace.getLong("committedSize"));
+            assertTrue(event.getLong("gcId") >= 0);
+            assertTrue(event.getString("when").equals("Before GC") || event.getString("when").equals("After GC"));
+            assertTrue(event.getLong("heapUsed") > 0);
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCHeapSummaryEvent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCHeapSummaryEvent.java
@@ -25,17 +25,18 @@
 
 package com.oracle.svm.test.jfr;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import jdk.jfr.consumer.RecordedObject;
 import org.junit.Test;
 
 import com.oracle.svm.core.jfr.JfrEvent;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedObject;
 
 public class TestGCHeapSummaryEvent extends JfrRecordingTest {
     @Test
@@ -52,11 +53,13 @@ public class TestGCHeapSummaryEvent extends JfrRecordingTest {
         assertTrue(events.size() > 0);
         for (RecordedEvent event : events) {
             RecordedObject heapSpace = event.getValue("heapSpace");
-            assertTrue(heapSpace.getLong("start") == -1);
-            assertTrue(heapSpace.getLong("committedEnd") == -1);
-            assertTrue(heapSpace.getLong("reservedEnd") == -1);
-            assertTrue(heapSpace.getLong("committedSize") > 0);
-            assertTrue(heapSpace.getLong("reservedSize") >= heapSpace.getLong("committedSize"));
+            assertEquals(-1, heapSpace.getLong("start"));
+            assertEquals(-1, heapSpace.getLong("committedEnd"));
+            assertEquals(-1, heapSpace.getLong("reservedEnd"));
+
+            long committedSize = heapSpace.getLong("committedSize");
+            assertTrue(committedSize > 0);
+            assertTrue(heapSpace.getLong("reservedSize") >= committedSize);
             assertTrue(event.getLong("gcId") >= 0);
             assertTrue(event.getString("when").equals("Before GC") || event.getString("when").equals("After GC"));
             assertTrue(event.getLong("heapUsed") > 0);


### PR DESCRIPTION
Very minor backport of https://github.com/oracle/graal/pull/8653 to correct some values in the JFR GCHeapSummary event. 
Low risk because it only modifies hard coded values and adds test code. 

Tested with `mx native-unittest`: passed. 