### PR TITLE
Backport of GR-52454: Include signal exit handlers in the image build if JFR

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateExitHandlerFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateExitHandlerFeature.java
@@ -34,7 +34,7 @@ import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 public class SubstrateExitHandlerFeature implements InternalFeature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
-        if (SubstrateOptions.InstallExitHandlers.getValue()) {
+        if (SubstrateOptions.InstallExitHandlers.getValue() || VMInspectionOptions.hasJfrSupport() || VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
             RuntimeSupport.getRuntimeSupport().addStartupHook(new SubstrateExitHandlerStartupHook());
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateExitHandlerFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateExitHandlerFeature.java
@@ -34,7 +34,7 @@ import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 public class SubstrateExitHandlerFeature implements InternalFeature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
-        if (SubstrateOptions.InstallExitHandlers.getValue() || VMInspectionOptions.hasJfrSupport() || VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
+        if (SubstrateOptions.InstallExitHandlers.getValue() || VMInspectionOptions.hasJfrSupport()) {
             RuntimeSupport.getRuntimeSupport().addStartupHook(new SubstrateExitHandlerStartupHook());
         }
     }


### PR DESCRIPTION
I'm backporting this change so that JFR is able to dump recordings by default if apps are stopped with SIGINT. This is important because without it users must manually specify a recording duration to create dump (or wait until the program finishes on its own). Previously `--install-exit-handlers` had to be specified at build time to get the same behaviour. 

This should be a low risk because the change only lessens the strictness of the check whether to install exist signal handlers.  This only changes the default behaviour when using JFR. 

Tested with `mx native-unittest`: passed
Also tested manually with:
```
mx native-image  --enable-monitoring=jfr -m jdk.httpserver
./jdk.httpserver -XX:StartFlightRecording=filename=rec.jfr 
SIGINT
jfr summary  rec.jfr
```
