### PR TITLE
Backport: svm: adopt "JDK-8328366: Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501"

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u3OrEarlier.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u3OrEarlier.java
@@ -31,7 +31,7 @@ import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 public class JDK21u3OrEarlier implements BooleanSupplier {
 
     public static final boolean jdk21u3OrEarlier = JavaVersionUtil.JAVA_SPEC < 21 ||
-            (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() <= 3);
+                    (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() <= 3);
 
     @Override
     public boolean getAsBoolean() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u4OrLater.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u4OrLater.java
@@ -31,7 +31,7 @@ import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 public class JDK21u4OrLater implements BooleanSupplier {
 
     public static final boolean jdk21u4OrLater = JavaVersionUtil.JAVA_SPEC > 21 ||
-            (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() >= 4);
+                    (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() >= 4);
 
     @Override
     public boolean getAsBoolean() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/RecomputedFields.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/RecomputedFields.java
@@ -33,6 +33,7 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.charset.CharsetDecoder;
+import java.security.AccessControlContext;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ForkJoinPool;
@@ -384,6 +385,15 @@ class ForkJoinPoolCommonAccessor {
         }
         return result;
     }
+}
+
+@TargetClass(value = java.util.concurrent.ForkJoinPool.class, innerClass = "DefaultForkJoinWorkerThreadFactory", onlyWith = JDK21OrLater.class)
+@SuppressWarnings("removal")
+final class Target_java_util_concurrent_ForkJoinPool_DefaultForkJoinWorkerThreadFactory {
+    @Alias @RecomputeFieldValue(kind = Reset) //
+    static AccessControlContext regularACC;
+    @Alias @RecomputeFieldValue(kind = Reset) //
+    static AccessControlContext commonACC;
 }
 
 /** Dummy class to have a class with the file's name. */


### PR DESCRIPTION
Hi,

Please review this backport of a fix from graal master needed by [JDK-8328366](url) which got backported to JDK 21.0.5 (included in build 3 and better). It's the same as the upstream fix with the following modifications:

- Use `JDK21OrLater.class` rather than `JDK23OrLater.class`
- Fix up the import manually since the context around the added import changed.

**Testing**

I've run the quarkus integration test that failed before this backport and ran it again after it. Result is passed, issue is gone. See https://github.com/graalvm/mandrel/issues/780 for details.

Thoughts?