### PR TITLE
Backport: Correctly handle resource include patterns

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
@@ -280,8 +280,26 @@ public final class Resources {
         assert MissingRegistrationUtils.throwMissingRegistrationErrors();
         synchronized (includePatterns) {
             updateTimeStamp();
-            includePatterns.add(new ModuleResourcePair(module, pattern));
+            includePatterns.add(new ModuleResourcePair(module, handleEscapedCharacters(pattern)));
         }
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)//
+    private static final String BEGIN_ESCAPED_SEQUENCE = "\\Q";
+
+    @Platforms(Platform.HOSTED_ONLY.class)//
+    private static final String END_ESCAPED_SEQUENCE = "\\E";
+
+    /*
+     * This handles generated include patterns which start and end with \Q and \E. The actual
+     * resource name is located inbetween those tags.
+     */
+    @Platforms(Platform.HOSTED_ONLY.class)
+    private static String handleEscapedCharacters(String pattern) {
+        if (pattern.startsWith(BEGIN_ESCAPED_SEQUENCE) && pattern.endsWith(END_ESCAPED_SEQUENCE)) {
+            return pattern.substring(BEGIN_ESCAPED_SEQUENCE.length(), pattern.length() - END_ESCAPED_SEQUENCE.length());
+        }
+        return pattern;
     }
 
     /**


### PR DESCRIPTION
Backport of https://github.com/oracle/graal/commit/2368a2f047ee917660055d3d994a6195334bb725, part of https://github.com/oracle/graal/pull/7827 

The patch didn't apply cleanly but the adjustments where trivial in line 283 (dropped the extra boolean argument and kept `add` instead of `put` method)

(cherry picked from commit 2368a2f047ee917660055d3d994a6195334bb725)

Closes https://github.com/oracle/graal/issues/9038