### PR TITLE
Fix build with --no-jlinking

### DIFF
--- a/sdk/mx.sdk/mx_sdk_vm_impl.py
+++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
@@ -2180,13 +2180,9 @@ class GraalVmBashLauncherBuildTask(GraalVmNativeImageBuildTask):
             extra_jvm_args = mx.list_to_cmd_line(image_config.extra_jvm_args)
             if not _jlink_libraries():
                 if mx.is_windows():
-                    extra_jvm_args = ' '.join([extra_jvm_args, r'--upgrade-module-path "%location%\..\..\jvmci\graal.jar"',
-                                               r'--add-modules org.graalvm.polyglot',
-                                               r'--module-path "%location%\..\..\truffle\truffle-api.jar:%location%\..\..\jvmci\polyglot.jar"'])
+                    extra_jvm_args = ' '.join([extra_jvm_args, r'--upgrade-module-path "%location%\..\..\jvmci\graal.jar"'])
                 else:
-                    extra_jvm_args = ' '.join([extra_jvm_args, '--upgrade-module-path "${location}/../../jvmci/graal.jar"',
-                                               '--add-modules org.graalvm.polyglot',
-                                               '--module-path "${location}/../../truffle/truffle-api.jar:${location}/../../jvmci/polyglot.jar"'])
+                    extra_jvm_args = ' '.join([extra_jvm_args, '--upgrade-module-path "${location}/../../jvmci/graal.jar"'])
             return extra_jvm_args
 
         def _get_option_vars():

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -587,8 +587,9 @@ public class NativeImage {
                 jars.addAll(getJars(libTruffleDir, "truffle-compiler"));
                 Path builderPath = rootDir.resolve(Paths.get("lib", "truffle", "builder"));
                 if (Files.exists(builderPath)) {
-                    jars.addAll(getJars(builderPath, "truffle-runtime-svm", "truffle-enterprise-svm"));
-                    if (libJvmciDir != null) {
+                    List<Path> truffleRuntimeSVMJars = getJars(builderPath, "truffle-runtime-svm", "truffle-enterprise-svm");
+                    jars.addAll(truffleRuntimeSVMJars);
+                    if (libJvmciDir != null && !truffleRuntimeSVMJars.isEmpty()) {
                         // truffle-runtime-svm depends on polyglot, which is not part of non-jlinked
                         // JDKs
                         jars.addAll(getJars(libJvmciDir, "polyglot"));

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -561,10 +561,12 @@ public class NativeImage {
          */
         public List<Path> getBuilderModulePath() {
             List<Path> result = new ArrayList<>();
-            // Non-jlinked JDKs need truffle and graal-sdk on the module path since they
-            // don't have those modules as part of the JDK.
+            // Non-jlinked JDKs need truffle and word, collections, nativeimage on the
+            // module path since they don't have those modules as part of the JDK. Note
+            // that graal-sdk is now obsolete after the split in GR-43819 (#7171)
             if (libJvmciDir != null) {
-                result.addAll(getJars(libJvmciDir, "graal-sdk", "enterprise-graal"));
+                result.addAll(getJars(libJvmciDir, "enterprise-graal"));
+                result.addAll(getJars(libJvmciDir, "word", "collections", "nativeimage"));
             }
             if (modulePathBuild) {
                 result.addAll(createTruffleBuilderModulePath());
@@ -586,6 +588,13 @@ public class NativeImage {
                 if (Files.exists(builderPath)) {
                     jars.addAll(getJars(builderPath, "truffle-runtime-svm", "truffle-enterprise-svm"));
                 }
+            }
+            /*
+             * Non-Jlinked JDKs don't have truffle-compiler as part of the JDK, however the native
+             * image builder still needs it
+             */
+            if (libJvmciDir != null) {
+                jars.addAll(getJars(rootDir.resolve(Paths.get("lib", "truffle")), "truffle-compiler"));
             }
 
             return jars;


### PR DESCRIPTION
This is a clean backport of https://github.com/oracle/graal/pull/7205 All three commits are simple `cherry-pick -x`.

With this, `mx --primary-suite vm --no-jlinking --env ce build` works. Similarly, `mx --primary-suite vm --env ce build`
still passes.

```
$ mx --primary-suite vm --no-jlinking --env ce graalvm-show
GraalVM distribution: GRAALVM_COMMUNITY_JAVA21
Version: 23.1.3
Config name: community
Components:
 - Graal SDK Compiler ('sdkc', /graalvm, experimental)
 - Graal SDK Native Image ('sdkni', /graalvm, experimental)
 - GraalVM compiler ('cmp', /graal, experimental)
 - LibGraal ('lg', /False, experimental)
 - Native Image ('ni', /svm, experimental)
 - Native Image Configure Tool ('nic', /svm, experimental)
 - Native Image licence files ('nil', /svm, experimental)
 - SubstrateVM ('svm', /svm, experimental)
 - SubstrateVM Foreign API Preview Feature ('svmforeign', /svm-preview, experimental)
 - SubstrateVM Static Libraries ('svmsl', /False, experimental)
 - Truffle Compiler ('tflc', /truffle, experimental)
 - Truffle Runtime SVM ('svmt', /truffle, experimental)
 - Truffle SVM Macro ('tflsm', /truffle-svm, experimental)
Launchers:
 - native-image (native, rebuildable)
 - native-image-configure (bash, rebuildable)
Libraries:
 - libjvmcicompiler.so (native, non-rebuildable)
 - libnative-image-agent.so (native, rebuildable)
 - libnative-image-diagnostics-agent.so (native, rebuildable)
No standalone
$ mx --primary-suite vm --no-jlinking --env ce graalvm-home
/disk/graal/upstream-sources/graalvm/sdk/mxbuild/linux-amd64/GRAALVM_COMMUNITY_JAVA21/graalvm-community-openjdk-21.0.5+3.1
$ /disk/graal/upstream-sources/graalvm/sdk/mxbuild/linux-amd64/GRAALVM_COMMUNITY_JAVA21/graalvm-community-openjdk-21.0.5+3.1/bin/native-image --version
native-image 21.0.5-beta 2024-10-15
GraalVM Runtime Environment Temurin-21.0.5+3-202408141902 (build 21.0.5-beta+3-ea)
Substrate VM Temurin-21.0.5+3-202408141902 (build 21.0.5-beta+3-ea, serial gc
```

Thoughts?

Closes: #12 