### PR TITLE
Backport: [GR-49816] Throw exception for null pointers passed to RuntimeJNIAccess / RuntimeReflection register methods

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/ReflectionRegistry.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/ReflectionRegistry.java
@@ -46,13 +46,7 @@ import java.util.Arrays;
 
 public interface ReflectionRegistry {
     default void register(ConfigurationCondition condition, Class<?>... classes) {
-        Arrays.stream(classes).forEach(clazz -> {
-            if (clazz == null) {
-                throw new NullPointerException("Cannot register null value as class for reflection. " +
-                                "Please ensure that all values you register are not null.");
-            }
-            register(condition, false, clazz);
-        });
+        Arrays.stream(classes).forEach(clazz -> register(condition, false, clazz));
     }
 
     void register(ConfigurationCondition condition, boolean unsafeAllocated, Class<?> clazz);

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/ReflectionRegistry.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/ReflectionRegistry.java
@@ -46,7 +46,13 @@ import java.util.Arrays;
 
 public interface ReflectionRegistry {
     default void register(ConfigurationCondition condition, Class<?>... classes) {
-        Arrays.stream(classes).forEach(clazz -> register(condition, false, clazz));
+        Arrays.stream(classes).forEach(clazz -> {
+            if (clazz == null) {
+                throw new NullPointerException("Cannot register null value as class for reflection. " +
+                        "Please ensure that all values you register are not null.");
+            }
+            register(condition, false, clazz);
+        });
     }
 
     void register(ConfigurationCondition condition, boolean unsafeAllocated, Class<?> clazz);

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/ReflectionRegistry.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/ReflectionRegistry.java
@@ -49,7 +49,7 @@ public interface ReflectionRegistry {
         Arrays.stream(classes).forEach(clazz -> {
             if (clazz == null) {
                 throw new NullPointerException("Cannot register null value as class for reflection. " +
-                        "Please ensure that all values you register are not null.");
+                                "Please ensure that all values you register are not null.");
             }
             register(condition, false, clazz);
         });

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1,7 +1,7 @@
 #
 # ----------------------------------------------------------------------------------------------------
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -296,7 +296,7 @@ def native_image_context(common_args=None, hosted_assertions=True, native_image_
     yield native_image_func
 
 native_image_context.hosted_assertions = ['-J-ea', '-J-esa']
-_native_unittest_features = '--features=com.oracle.svm.test.ImageInfoTest$TestFeature,com.oracle.svm.test.ServiceLoaderTest$TestFeature,com.oracle.svm.test.SecurityServiceTest$TestFeature'
+_native_unittest_features = '--features=com.oracle.svm.test.ImageInfoTest$TestFeature,com.oracle.svm.test.ServiceLoaderTest$TestFeature,com.oracle.svm.test.SecurityServiceTest$TestFeature,com.oracle.svm.test.ReflectionRegistrationTest$TestFeature'
 
 IMAGE_ASSERTION_FLAGS = svm_experimental_options(['-H:+VerifyGraalGraphs', '-H:+VerifyPhases'])
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ConditionalConfigurationRegistry.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ConditionalConfigurationRegistry.java
@@ -38,6 +38,14 @@ public abstract class ConditionalConfigurationRegistry {
     private final Map<String, Collection<Runnable>> pendingReachabilityHandlers = new ConcurrentHashMap<>();
 
     protected void registerConditionalConfiguration(ConfigurationCondition condition, Runnable runnable) {
+        if (condition == null) {
+            throw new NullPointerException("Cannot use null value as condition for conditional configuration. " +
+                            "Please ensure that you register a non-null condition.");
+        }
+        if (runnable == null) {
+            throw new NullPointerException("Cannot use null value as runnable for conditional configuration. " +
+                            "Please ensure that you register a non-null runnable.");
+        }
         if (ConfigurationCondition.alwaysTrue().equals(condition)) {
             /* analysis optimization to include new types as early as possible */
             runnable.run();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ConditionalConfigurationRegistry.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ConditionalConfigurationRegistry.java
@@ -26,6 +26,7 @@ package com.oracle.svm.hosted;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -38,14 +39,8 @@ public abstract class ConditionalConfigurationRegistry {
     private final Map<String, Collection<Runnable>> pendingReachabilityHandlers = new ConcurrentHashMap<>();
 
     protected void registerConditionalConfiguration(ConfigurationCondition condition, Runnable runnable) {
-        if (condition == null) {
-            throw new NullPointerException("Cannot use null value as condition for conditional configuration. " +
-                            "Please ensure that you register a non-null condition.");
-        }
-        if (runnable == null) {
-            throw new NullPointerException("Cannot use null value as runnable for conditional configuration. " +
-                            "Please ensure that you register a non-null runnable.");
-        }
+        Objects.requireNonNull(condition, "Cannot use null value as condition for conditional configuration. Please ensure that you register a non-null condition.");
+        Objects.requireNonNull(runnable, "Cannot use null value as runnable for conditional configuration. Please ensure that you register a non-null runnable.");
         if (ConfigurationCondition.alwaysTrue().equals(condition)) {
             /* analysis optimization to include new types as early as possible */
             runnable.run();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -56,6 +56,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -166,6 +167,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     @Override
     public void register(ConfigurationCondition condition, boolean unsafeInstantiated, Class<?> clazz) {
+        Objects.requireNonNull(clazz, () -> nullErrorMessage("class"));
         checkNotSealed();
         register(analysisUniverse -> registerConditionalConfiguration(condition,
                         () -> analysisUniverse.getBigbang().postTask(debug -> registerClass(clazz, unsafeInstantiated))));
@@ -281,13 +283,10 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     @Override
     public void register(ConfigurationCondition condition, boolean queriedOnly, Executable... executables) {
+        requireNonNull(executables, "executable");
         checkNotSealed();
         register(analysisUniverse -> registerConditionalConfiguration(condition, () -> {
             for (Executable executable : executables) {
-                if (executable == null) {
-                    throw new NullPointerException("Cannot register null value as executable for reflection. " +
-                                    "Please ensure that all values you register are not null.");
-                }
                 analysisUniverse.getBigbang().postTask(debug -> registerMethod(queriedOnly, executable));
             }
         }));
@@ -413,6 +412,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     @Override
     public void register(ConfigurationCondition condition, boolean finalIsWritable, Field... fields) {
+        requireNonNull(fields, "field");
         checkNotSealed();
         registerInternal(condition, fields);
     }
@@ -420,10 +420,6 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
     private void registerInternal(ConfigurationCondition condition, Field... fields) {
         register(analysisUniverse -> registerConditionalConfiguration(condition, () -> {
             for (Field field : fields) {
-                if (field == null) {
-                    throw new NullPointerException("Cannot register null value as field for reflection. " +
-                                    "Please ensure that all values you register are not null.");
-                }
                 analysisUniverse.getBigbang().postTask(debug -> registerField(field));
             }
         }));
@@ -1079,5 +1075,15 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
     @Override
     public int getReflectionFieldsCount() {
         return registeredFields.size();
+    }
+
+    private static void requireNonNull(Object[] values, String kind) {
+        for (Object value : values) {
+            Objects.requireNonNull(value, () -> nullErrorMessage(kind));
+        }
+    }
+
+    private static String nullErrorMessage(String kind) {
+        return "Cannot register null value as " + kind + " for reflection. Please ensure that all values you register are not null.";
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -284,6 +284,10 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
         checkNotSealed();
         register(analysisUniverse -> registerConditionalConfiguration(condition, () -> {
             for (Executable executable : executables) {
+                if (executable == null) {
+                    throw new NullPointerException("Cannot register null value as executable for reflection. " +
+                                    "Please ensure that all values you register are not null.");
+                }
                 analysisUniverse.getBigbang().postTask(debug -> registerMethod(queriedOnly, executable));
             }
         }));
@@ -416,6 +420,10 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
     private void registerInternal(ConfigurationCondition condition, Field... fields) {
         register(analysisUniverse -> registerConditionalConfiguration(condition, () -> {
             for (Field field : fields) {
+                if (field == null) {
+                    throw new NullPointerException("Cannot register null value as field for reflection. " +
+                                    "Please ensure that all values you register are not null.");
+                }
                 analysisUniverse.getBigbang().postTask(debug -> registerField(field));
             }
         }));

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ReflectionRegistrationTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ReflectionRegistrationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import com.oracle.svm.hosted.FeatureImpl;
+import com.oracle.svm.hosted.substitute.SubstitutionReflectivityFilter;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
+import org.junit.Test;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+
+/**
+ * Tests the {@link RuntimeReflection}.
+ */
+public class ReflectionRegistrationTest {
+
+    public static class TestFeature implements Feature {
+
+        @SuppressWarnings("unused")//
+        int unusedVariableOne = 1;
+        @SuppressWarnings("unused")//
+        int unusedVariableTwo = 2;
+
+        @Override
+        public void beforeAnalysis(final BeforeAnalysisAccess access) {
+            try {
+                RuntimeReflection.register((Class<?>) null);
+                assert false;
+            } catch (NullPointerException e) {
+                assert e.getMessage().startsWith("Cannot register null value");
+            }
+            try {
+                RuntimeReflection.register((Executable) null);
+                assert false;
+            } catch (NullPointerException e) {
+                assert e.getMessage().startsWith("Cannot register null value");
+            }
+            try {
+                RuntimeReflection.register((Field) null);
+                assert false;
+            } catch (NullPointerException e) {
+                assert e.getMessage().startsWith("Cannot register null value");
+            }
+
+            try {
+                ImageSingletons.lookup(RuntimeReflectionSupport.class).register(null, this.getClass());
+                assert false;
+            } catch (NullPointerException e) {
+                assert e.getMessage().startsWith("Cannot use null value");
+            }
+
+            try {
+                ImageSingletons.lookup(RuntimeReflectionSupport.class).register(null, true, this.getClass().getMethods());
+                assert false;
+            } catch (NullPointerException e) {
+                assert e.getMessage().startsWith("Cannot use null value");
+            }
+
+            try {
+                ImageSingletons.lookup(RuntimeReflectionSupport.class).register(null, true, this.getClass().getFields());
+                assert false;
+            } catch (NullPointerException e) {
+                assert e.getMessage().startsWith("Cannot use null value");
+            }
+
+            FeatureImpl.BeforeAnalysisAccessImpl impl = (FeatureImpl.BeforeAnalysisAccessImpl) access;
+            try {
+                SubstitutionReflectivityFilter.shouldExclude((Class<?>) null, impl.getMetaAccess(), impl.getUniverse());
+                assert false;
+            } catch (NullPointerException e) {
+                // expected
+            }
+            try {
+                SubstitutionReflectivityFilter.shouldExclude((Executable) null, impl.getMetaAccess(), impl.getUniverse());
+                assert false;
+            } catch (NullPointerException e) {
+                // expected
+            }
+            try {
+                SubstitutionReflectivityFilter.shouldExclude((Field) null, impl.getMetaAccess(), impl.getUniverse());
+                assert false;
+            } catch (NullPointerException e) {
+                // expected
+            }
+        }
+
+    }
+
+    @Test
+    public void test() {
+        // nothing to do
+    }
+}


### PR DESCRIPTION
Almost a clean backport of: https://github.com/oracle/graal/pull/6985 to bring upstream community repo more in sync with downstream Mandrel 23.1 release branch.

The only difference is in https://github.com/graalvm/graalvm-community-jdk21u/commit/6af144fce4e6e541164082918070b29ce8111481 where the [original](https://github.com/oracle/graal/pull/6985/commits/d996f323b7c6ce796caccff6ae50bd1c2fa5a81f) had some import re-shuffeling and the rename from `methods` to `executables`, which isn't done in the backport.

Thoughts?