### PR TITLE
Partial backport of [GR-48529] Use the API flag in the init hint

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/SubstrateOptionsParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/SubstrateOptionsParser.java
@@ -195,7 +195,9 @@ public class SubstrateOptionsParser {
                     }
                 }
             }
-            return HOSTED_OPTION_PREFIX + value + option;
+            String optionString = HOSTED_OPTION_PREFIX + value + option;
+            assert apiOptionName == null : "The API option " + apiOptionName + " not found for " + optionString;
+            return optionString;
         } else {
             String apiOptionWithValue = null;
             for (APIOption apiOption : apiOptions) {


### PR DESCRIPTION
https://github.com/oracle/graal/pull/7406 was the original PR upstream. 9c5bcf994cd774a755be0fb548a3e3120a47605d is already present and this adds the second commit as well.

It's another backport we have in the Mandrel 23.1 downstream release repo and should move upstream.

Thoughts?