### PR TITLE
Remove trailing whitespace in comments

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JRTSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JRTSupport.java
@@ -54,7 +54,7 @@ import com.oracle.svm.core.util.VMError;
 
 /**
  * Support to access system Java modules and the <b>jrt://</b> file system.
- * 
+ *
  * <p>
  * <b>javac</b> and other tools that access the system modules, depend on the
  * <b>-Djava.home=/path/to/jdk</b> property to be set e.g. required by

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1138,7 +1138,7 @@ public class NativeImage {
          * only allow inlining when JIT compiling after n invocations. PROFILE_GWT is used to
          * profile "guard with test" method handles and speculate on a constant guard value, making
          * the other branch statically unreachable for JIT compilation.
-         * 
+         *
          * Both are used for example in the implementation of record hashCode/equals methods. We
          * disable this behavior in the image builder because for AOT compilation, profiling and
          * speculation are never useful. Instead, it prevents optimizing the method handles for AOT


### PR DESCRIPTION
This is a no-op change, but makes downstream Mandrel 23.1 be in sync with the upstream community repo.

Thoughts?