### PR TITLE
New dev cycle GraalVM Community 23.1.5

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -4,8 +4,8 @@ suite = {
   "sourceinprojectwhitelist" : [],
 
   "groupId" : "org.graalvm.compiler",
-  "version" : "23.1.3",
-  "release" : True,
+  "version" : "23.1.5",
+  "release" : False,
   "url" : "http://www.graalvm.org/",
   "developer" : {
     "name" : "GraalVM Development",

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -23,8 +23,8 @@
 suite = {
     "mxversion": "6.44.0",
     "name": "espresso",
-    "version" : "23.1.3",
-    "release" : True,
+    "version" : "23.1.5",
+    "release" : False,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -43,8 +43,8 @@ suite = {
 
   "name" : "regex",
 
-  "version" : "23.1.3",
-  "release" : True,
+  "version" : "23.1.5",
+  "release" : False,
   "groupId" : "org.graalvm.regex",
   "url" : "http://www.graalvm.org/",
   "developer" : {

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -41,8 +41,8 @@
 suite = {
   "mxversion": "6.39.0",
   "name" : "sdk",
-  "version" : "23.1.3",
-  "release" : True,
+  "version" : "23.1.5",
+  "release" : False,
   "sourceinprojectwhitelist" : [],
   "url" : "https://github.com/oracle/graal",
   "groupId" : "org.graalvm.sdk",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -2,8 +2,8 @@
 suite = {
     "mxversion": "6.27.1",
     "name": "substratevm",
-    "version" : "23.1.3",
-    "release" : True,
+    "version" : "23.1.5",
+    "release" : False,
     "url" : "https://github.com/oracle/graal/tree/master/substratevm",
 
     "groupId" : "org.graalvm.nativeimage",

--- a/tools/mx.tools/suite.py
+++ b/tools/mx.tools/suite.py
@@ -26,8 +26,8 @@ suite = {
     "defaultLicense" : "GPLv2-CPE",
 
     "groupId" : "org.graalvm.tools",
-    "version" : "23.1.3",
-    "release" : True,
+    "version" : "23.1.5",
+    "release" : False,
     "url" : "http://openjdk.java.net/projects/graal",
     "developer" : {
         "name" : "GraalVM Development",

--- a/truffle/external_repos/simplelanguage/pom.xml
+++ b/truffle/external_repos/simplelanguage/pom.xml
@@ -48,7 +48,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <m2e.apt.activation>jdt_apt</m2e.apt.activation>
     <!-- If you update this number make sure the VERSION value in ./sl matches -->
-    <graalvm.version>23.1.3-dev</graalvm.version>
+    <graalvm.version>23.1.5-dev</graalvm.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>

--- a/truffle/external_repos/simplelanguage/sl
+++ b/truffle/external_repos/simplelanguage/sl
@@ -41,7 +41,7 @@
 #
 
 # If you update this number make sure the graalvm.version value in ./pom.xml matches
-VERSION="23.1.3-dev"
+VERSION="23.1.5-dev"
 # If you update this number make sure the antlr.version value in language/pom.xml matches
 ANTLR_VERSION="4.12.0"
 

--- a/truffle/external_repos/simpletool/pom.xml
+++ b/truffle/external_repos/simpletool/pom.xml
@@ -49,7 +49,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <graalvm.version>23.1.3-dev</graalvm.version>
+    <graalvm.version>23.1.5-dev</graalvm.version>
   </properties>
   <profiles>
     <profile>

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -41,8 +41,8 @@
 suite = {
   "mxversion": "6.39.0",
   "name" : "truffle",
-  "version" : "23.1.3",
-  "release" : True,
+  "version" : "23.1.5",
+  "release" : False,
   "groupId" : "org.graalvm.truffle",
   "sourceinprojectwhitelist" : [],
   "url" : "http://openjdk.java.net/projects/graal",

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -1,8 +1,8 @@
 suite = {
     "name": "vm",
-    "version" : "23.1.3",
+    "version" : "23.1.5",
     "mxversion": "6.41.0",
-    "release" : True,
+    "release" : False,
     "groupId" : "org.graalvm",
 
     "url" : "http://www.graalvm.org/",

--- a/wasm/mx.wasm/suite.py
+++ b/wasm/mx.wasm/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "6.41.0",
   "name" : "wasm",
   "groupId" : "org.graalvm.wasm",
-  "version" : "23.1.3",
+  "version" : "23.1.5",
   "versionConflictResolution" : "latest",
   "url" : "http://graalvm.org/",
   "developer" : {


### PR DESCRIPTION
As PR title goes. Simple version bump. The release in October will be `23.1.5` (or `for JDK 21.0.5`).