### PR TITLE
Switch gates to use OpenJDK EA builds instead of LabsJDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,11 +142,16 @@ jobs:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
-    - name: Fetch LabsJDK
+    - name: Get OpenJDK with static libs
       env: ${{ matrix.env }}
       run: |
-        mkdir jdk-dl
-        ${MX_PATH}/mx --java-home= fetch-jdk --jdk-id labsjdk-ce-${JDK_VERSION} --to jdk-dl --alias ${JAVA_HOME}
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        mkdir -p ${JAVA_HOME}
+        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
+        tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+        echo ${JAVA_HOME}
+        ${JAVA_HOME}/bin/java --version
     - name: Update dependency cache
       if: ${{ env.MX_RUNS_DEBUG == 'true' || env.MX_RUNS_STYLE == 'true' }}
       run: sudo apt update

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -16,13 +16,14 @@ env:
   DB_PASSWORD: hibernate_orm_test
   DB_USER: hibernate_orm_test
   GRAALVM_HOME: ${{ github.workspace }}/graalvm
-  LABSJDK_HOME: ${{ github.workspace }}/jdk
+  JAVA_HOME: ${{ github.workspace }}/jdk
   LANG: en_US.UTF-8 # Workaround testsuite locale issue
   MX_GIT_CACHE: refcache
   MX_PATH: ${{ github.workspace }}/mx
   MX_PYTHON: python3.8
   NATIVE_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs -Dquarkus.native.container-build=false"
   QUARKUS_PATH: ${{ github.workspace }}/quarkus
+  JDK_VERSION: "21"
 
 permissions: {}
 jobs:
@@ -69,13 +70,17 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: |
           ${{ runner.os }}-mx-
-    - name: Fetch LabsJDK
+    - name: Get OpenJDK with static libs
       run: |
-        mkdir jdk-dl
-        ${MX_PATH}/mx --java-home= fetch-jdk --jdk-id labsjdk-ce-21 --to jdk-dl --alias ${LABSJDK_HOME}
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        mkdir -p ${JAVA_HOME}
+        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
+        tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+        echo ${JAVA_HOME}
+        ${JAVA_HOME}/bin/java --version
     - name: Build graalvm native-image
       run: |
-        export JAVA_HOME=${LABSJDK_HOME}
         cd substratevm
         ${MX_PATH}/mx --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" build
         mv $(${MX_PATH}/mx --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" graalvm-home) ${GRAALVM_HOME}

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -16,7 +16,7 @@ env:
   DB_PASSWORD: hibernate_orm_test
   DB_USER: hibernate_orm_test
   GRAALVM_HOME: ${{ github.workspace }}/graalvm
-  JAVA_HOME: ${{ github.workspace }}/jdk
+  BOOTSTRAP_JAVA_HOME: ${{ github.workspace }}/jdk
   LANG: en_US.UTF-8 # Workaround testsuite locale issue
   MX_GIT_CACHE: refcache
   MX_PATH: ${{ github.workspace }}/mx
@@ -74,16 +74,16 @@ jobs:
       run: |
         curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
         curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
-        mkdir -p ${JAVA_HOME}
-        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
-        tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
-        echo ${JAVA_HOME}
-        ${JAVA_HOME}/bin/java --version
+        mkdir -p ${BOOTSTRAP_JAVA_HOME}
+        tar xf jdk.tar.gz -C ${BOOTSTRAP_JAVA_HOME} --strip-components=1
+        tar xf jdk-static-libs.tar.gz -C ${BOOTSTRAP_JAVA_HOME} --strip-components=1
+        echo ${BOOTSTRAP_JAVA_HOME}
+        ${BOOTSTRAP_JAVA_HOME}/bin/java --version
     - name: Build graalvm native-image
       run: |
         cd substratevm
-        ${MX_PATH}/mx --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" build
-        mv $(${MX_PATH}/mx --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" graalvm-home) ${GRAALVM_HOME}
+        ${MX_PATH}/mx --java-home=${BOOTSTRAP_JAVA_HOME} --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" build
+        mv $(${MX_PATH}/mx --java-home=${BOOTSTRAP_JAVA_HOME} --native=native-image,lib:jvmcicompiler --components="Native Image,LibGraal" graalvm-home) ${GRAALVM_HOME}
         ${GRAALVM_HOME}/bin/native-image --version
     - name: Tar GraalVM
       shell: bash
@@ -93,6 +93,11 @@ jobs:
       with:
         name: graalvm
         path: graalvm.tgz
+    - name: Use JDK 17 for Quarkus build
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
     - name: Build Quarkus
       run: |
         cd ${QUARKUS_PATH}
@@ -154,11 +159,11 @@ jobs:
         if: startsWith(matrix.os-name, 'ubuntu')
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - uses: graalvm/setup-graalvm@v1
+      - name: Use JDK 17 for Quarkus build
+        uses: actions/setup-java@v4
         with:
-          version: 'latest'
-          java-version: '17'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          distribution: temurin
+          java-version: 17
       - name: Build with Maven
         if: startsWith(matrix.os-name, 'ubuntu')
         env:


### PR DESCRIPTION
[LabsJDK CE](https://github.com/graalvm/labs-openjdk-21/) is no longer maintained. Community builds should rely on OpenJDK builds instead. 