### PR TITLE
Backport: Use JVMCI for @Delete classes

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
@@ -635,23 +635,35 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
 
     private void handleDeletedClass(Class<?> originalClass, Delete deleteAnnotation) {
         if (NativeImageOptions.ReportUnsupportedElementsAtRuntime.getValue()) {
+            ResolvedJavaType type = metaAccess.lookupJavaType(originalClass);
+
+            try {
+                type.link();
+            } catch (LinkageError ignored) {
+                /*
+                 * Ignore any linking errors. A type that cannot be linked doesn't need elements
+                 * replaced: it will simply fail at runtime with the same linkage error before
+                 * reaching those elements.
+                 */
+                return;
+            }
+
             /*
              * We register all methods and fields as deleted. That still allows usage of the type in
              * type checks.
              */
-            for (Executable m : originalClass.getDeclaredMethods()) {
-                ResolvedJavaMethod method = metaAccess.lookupJavaMethod(m);
+            for (ResolvedJavaMethod method : type.getDeclaredMethods()) {
                 registerAsDeleted(null, method, deleteAnnotation);
             }
-            for (Executable m : originalClass.getDeclaredConstructors()) {
-                ResolvedJavaMethod method = metaAccess.lookupJavaMethod(m);
-                registerAsDeleted(null, method, deleteAnnotation);
+            for (ResolvedJavaMethod constructor : type.getDeclaredConstructors()) {
+                registerAsDeleted(null, constructor, deleteAnnotation);
             }
-            for (Field f : originalClass.getDeclaredFields()) {
-                ResolvedJavaField field = metaAccess.lookupJavaField(f);
-                registerAsDeleted(null, field, deleteAnnotation);
+            for (ResolvedJavaField f : type.getInstanceFields(false)) {
+                registerAsDeleted(null, f, deleteAnnotation);
             }
-
+            for (ResolvedJavaField f : type.getStaticFields()) {
+                registerAsDeleted(null, f, deleteAnnotation);
+            }
         } else {
             deleteAnnotations.put(metaAccess.lookupJavaType(originalClass), deleteAnnotation);
         }


### PR DESCRIPTION
Partial backport of https://github.com/oracle/graal/pull/8815

cherry picked from commit [30ae9d3c8dce269e1bcb9f1a090fddfff7d8eea4](https://github.com/oracle/graal/commit/30ae9d3c8dce269e1bcb9f1a090fddfff7d8eea4) trimmed to not include the API flag documentation change https://github.com/oracle/graal/commit/30ae9d3c8dce269e1bcb9f1a090fddfff7d8eea4#diff-b23354f77f5218c2b45167bd6d7887269ae1e8a91255e3db814e24706637327cL146-R146

Fixes https://github.com/oracle/graal/issues/1725

Reproducer:

```
cd /tmp
git clone --branch 2024-09-13-delete-no-class-def-found https://github.com/zakkak/issue-reproducers reproducers
cd reproducers
mvn package
# run with Unreachable on the classpath
java -cp target/classes Main
# run with Unreachable not on the classpath
java \
  -jar target/reproducer-1.0-SNAPSHOT.jar
# generate native-image with Unreachable not on the classpath
native-image \
  --no-fallback \
  -H:+ReportExceptionStackTraces \
  -jar target/reproducer-1.0-SNAPSHOT.jar
# Run binary
./reproducer-1.0-SNAPSHOT
# generate native-image with Unreachable not on the classpath and pass --report-unsupported-elements-at-runtime
native-image \
  --no-fallback \
  --report-unsupported-elements-at-runtime \
  -H:+ReportExceptionStackTraces \
  -jar target/reproducer-1.0-SNAPSHOT.jar
# Build fails without the patch
```
