### PR TITLE
[Backport]  Delete native methods from java.lang.Thread

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
@@ -623,6 +623,10 @@ public final class Target_java_lang_Thread {
         return JavaThreads.getStackTrace(false, JavaThreads.fromTarget(this));
     }
 
+    @Delete
+    @SuppressWarnings({"static-method"})
+    private native Object getStackTrace0();
+
     /** @see com.oracle.svm.core.jdk.StackTraceUtils#asyncGetStackTrace */
     @Delete
     @TargetElement(onlyWith = JDK19OrLater.class)
@@ -798,6 +802,9 @@ public final class Target_java_lang_Thread {
     @Alias
     @TargetElement(onlyWith = JDK19OrLater.class)
     native long threadId();
+
+    @Delete
+    static native long getNextThreadIdOffset();
 }
 
 @TargetClass(value = Thread.class, innerClass = "Builder", onlyWith = JDK19OrLater.class)


### PR DESCRIPTION
'getStackTrace0' is only used in asyncGetStackTrace() which is deleted as well.
Thread.getStackTrace()  is replaced by PlatformThreads.getStackTrace(). So it's not
reachable.

'getNextThreadIdOffset()' is only used in ThreadIdentifiers private class which is
substituted in JDKs better than JDK 19 (which includes 21). So won't be reachable either.

Fixes: https://github.com/graalvm/graalvm-community-jdk21u/issues/28

This is a partial backport of:
"Introudce a mode to unconditionally include classes" https://github.com/oracle/graal/commit/369f0ff8
to address https://github.com/oracle/graal/issues/9672

Only take the java.lang.Thread native method deletions as that's sufficient to fix
the issue reported in https://github.com/graalvm/graalvm-community-jdk21u/issues/28.