### PR TITLE
8349158: ArrayIndexOutOfBoundsException in MonitorSnippets.java

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/replacements/MonitorSnippets.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/replacements/MonitorSnippets.java
@@ -891,7 +891,6 @@ public class MonitorSnippets implements Snippets {
                 args.add("object", monitorenterNode.object());
                 args.addConst("lockDepth", monitorenterNode.getMonitorId().getLockDepth());
                 args.addConst("trace", isTracingEnabledForType(monitorenterNode.object()) || isTracingEnabledForMethod(graph));
-                args.addConst("counters", counters);
             }
 
             template(tool, monitorenterNode, args).instantiate(tool.getMetaAccess(), monitorenterNode, DEFAULT_REPLACER, args);
@@ -903,14 +902,17 @@ public class MonitorSnippets implements Snippets {
             Arguments args;
             if (useFastLocking) {
                 args = new Arguments(monitorexit, graph.getGuardsStage(), tool.getLoweringStage());
+                args.add("object", monitorexitNode.object());
+                args.addConst("lockDepth", monitorexitNode.getMonitorId().getLockDepth());
+                args.addConst("threadRegister", registers.getThreadRegister());
+                args.addConst("trace", isTracingEnabledForType(monitorexitNode.object()) || isTracingEnabledForMethod(graph));
+                args.addConst("counters", counters);
             } else {
                 args = new Arguments(monitorexitStub, graph.getGuardsStage(), tool.getLoweringStage());
+                args.add("object", monitorexitNode.object());
+                args.addConst("lockDepth", monitorexitNode.getMonitorId().getLockDepth());
+                args.addConst("trace", isTracingEnabledForType(monitorexitNode.object()) || isTracingEnabledForMethod(graph));
             }
-            args.add("object", monitorexitNode.object());
-            args.addConst("lockDepth", monitorexitNode.getMonitorId().getLockDepth());
-            args.addConst("threadRegister", registers.getThreadRegister());
-            args.addConst("trace", isTracingEnabledForType(monitorexitNode.object()) || isTracingEnabledForMethod(graph));
-            args.addConst("counters", counters);
 
             template(tool, monitorexitNode, args).instantiate(tool.getMetaAccess(), monitorexitNode, DEFAULT_REPLACER, args);
         }


### PR DESCRIPTION
The lowering of MonitorEnterNode and MonitorExitNode has an issue where it "pushes" more arguments than needed by the callee (monitorenterStub and monitorexitStub, respectively) when JVMCIUseFastLocking is disabled. See Stacktrace on the JBS issue. The issue isn't present in Graal mainline because there was some refactoring in the code which fixed the issue.

Tested internally in Linux & Mac using JTREG & JCK.

JBS issue: https://bugs.openjdk.org/browse/JDK-8349158
Fixes: https://github.com/graalvm/graalvm-community-jdk21u/issues/43