### PR TITLE
Merge upstream vm-23.1.5 tag 1st batch

### DIFF
--- a/ci/ci_common/bench-common.libsonnet
+++ b/ci/ci_common/bench-common.libsonnet
@@ -31,6 +31,17 @@
       else true
   },
 
+  # max number of threads to use for benchmarking in general
+  # the goal being to limit parallelism on very large servers which may not be respresentative of real-world scenarios
+  bench_max_threads:: {
+   restrict_threads:: 36
+  },
+
+  bench_no_thread_cap:: {
+    restrict_threads:: null,
+    should_use_hwloc:: false
+  },
+
   bench_hw:: {
     _bench_machine:: {
       targets+: ["bench"],
@@ -42,6 +53,7 @@
       numa_nodes:: [],
       is_numa:: std.length(self.numa_nodes) > 0,
       num_threads:: error "num_threads must bet set!",
+      hyperthreading:: true,
       threads_per_node:: if self.is_numa then self.num_threads / std.length(self.numa_nodes) else self.num_threads,
     },
 
@@ -51,6 +63,13 @@
       numa_nodes:: [0, 1],
       default_numa_node:: 0,
       num_threads:: 72
+    },
+    e3:: common.linux_amd64 + self._bench_machine + {
+      machine_name:: "e3",
+      capabilities: ["e3", "tmpfs25g", "linux", "amd64"],
+      numa_nodes:: [0, 1],
+      default_numa_node:: 1,
+      num_threads:: 256
     },
     x82:: common.linux_amd64 + self._bench_machine + {
       machine_name:: "x82",
@@ -62,31 +81,29 @@
     xgene3:: common.linux_aarch64 + self._bench_machine + {
       machine_name:: "xgene3",
       capabilities+: [],
-      num_threads:: 32
+      num_threads:: 32,
+      hyperthreading:: false
     },
     a12c:: common.linux_aarch64 + self._bench_machine + {
       machine_name:: "a12c",
       capabilities+: ["no_frequency_scaling", "tmpfs25g"],
       numa_nodes:: [0, 1],
       default_numa_node:: 0,
-      num_threads:: 160
+      num_threads:: 160,
+      hyperthreading:: false
     }
   },
 
-  hwlocIfNuma(numa, cmd, node=0)::
-    if numa then
+  hwloc_cmd(cmd, num_threads, node, hyperthreading, max_threads_per_node)::
+    if num_threads == null then
       ["hwloc-bind", "--cpubind", "node:"+node, "--membind", "node:"+node, "--"] + cmd
     else
-      cmd,
-
-  parallelHwloc(cmd_node0, cmd_node1)::
-    // Returns a list of commands that will run cmd_nod0 on NUMA node 0
-    // concurrently with cmd_node1 on NUMA node 1 and then wait for both to complete.
-    [
-      $.hwlocIfNuma(true, cmd_node0, node=0) + ["&"],
-      $.hwlocIfNuma(true, cmd_node1, node=1) + ["&"],
-      ["wait"]
-    ],
+      local threads = if num_threads != null then num_threads else max_threads_per_node;
+      assert if hyperthreading then threads % 2 == 0 else true: "It is required to bind to an even number of threads on hyperthreaded machines. Got requested "+threads+" threads";
+      assert threads <= max_threads_per_node: "Benchmarking must run on a single NUMA node for stability reasons. Got requested "+threads+" threads but the machine has only "+max_threads_per_node+" threads per node";      local cores = if hyperthreading then "0-"+((threads/2)-1)+".pu:0-1" else "0-"+(threads-1)+".pu:0";
+      local cpu_bind = if hyperthreading then "node:"+node+".core:"+cores else "node:"+node+".core:"+cores+".pu:0";
+      ["hwloc-bind", "--cpubind", cpu_bind, "--membind", "node:"+node, "--"] + cmd
+  ,
 
   // building block used to generate fork builds
   many_forks_benchmarking:: common.build_base + {

--- a/ci/ci_common/bench-common.libsonnet
+++ b/ci/ci_common/bench-common.libsonnet
@@ -57,13 +57,6 @@
       threads_per_node:: if self.is_numa then self.num_threads / std.length(self.numa_nodes) else self.num_threads,
     },
 
-    x52:: common.linux_amd64 + self._bench_machine + {
-      machine_name:: "x52",
-      capabilities+: ["no_frequency_scaling", "tmpfs25g"],
-      numa_nodes:: [0, 1],
-      default_numa_node:: 0,
-      num_threads:: 72
-    },
     e3:: common.linux_amd64 + self._bench_machine + {
       machine_name:: "e3",
       capabilities: ["e3", "tmpfs25g", "linux", "amd64"],

--- a/common.json
+++ b/common.json
@@ -22,9 +22,9 @@
     "labsjdk-ce-21":      {"name": "labsjdk",   "version": "ce-21.0.2+13-jvmci-23.1-b30", "platformspecific": true },
     "labsjdk-ce-21Debug": {"name": "labsjdk",   "version": "ce-21.0.2+13-jvmci-23.1-b30-debug", "platformspecific": true },
     "labsjdk-ce-21-llvm": {"name": "labsjdk",   "version": "ce-21.0.2+13-jvmci-23.1-b30-sulong", "platformspecific": true },
-    "labsjdk-ee-21":      {"name": "labsjdk",   "version": "ee-21.0.3+7-jvmci-23.1-b37", "platformspecific": true },
-    "labsjdk-ee-21Debug": {"name": "labsjdk",   "version": "ee-21.0.3+7-jvmci-23.1-b37-debug", "platformspecific": true },
-    "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.3+7-jvmci-23.1-b37-sulong", "platformspecific": true },
+    "labsjdk-ee-21":      {"name": "labsjdk",   "version": "ee-21.0.4+3-jvmci-23.1-b38", "platformspecific": true },
+    "labsjdk-ee-21Debug": {"name": "labsjdk",   "version": "ee-21.0.4+3-jvmci-23.1-b38-debug", "platformspecific": true },
+    "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.4+3-jvmci-23.1-b38-sulong", "platformspecific": true },
 
     "oraclejdk22":        {"name": "jpg-jdk",   "version": "22",      "build_id": "2", "release": true, "platformspecific": true, "extrabundles": ["static-libs"]}
   },

--- a/compiler/ci/ci_common/benchmark-builders.jsonnet
+++ b/compiler/ci/ci_common/benchmark-builders.jsonnet
@@ -7,40 +7,40 @@
 
   local main_builds = std.flattenArrays([
     [
-    c.daily + c.opt_post_merge + hw.x52 + jdk + cc.libgraal + bench.dacapo + { unicorn_pull_request_benchmarking:: {name: 'libgraal', metrics: ['time']}},
-    c.weekly                   + hw.x52 + jdk + cc.libgraal + bench.dacapo_size_variants,
-    c.weekly                   + hw.x52 + jdk + cc.libgraal + bench.dacapo_timing,
-    c.daily + c.opt_post_merge + hw.x52 + jdk + cc.libgraal + bench.scala_dacapo + {unicorn_pull_request_benchmarking:: 'libgraal'},
-    c.weekly                   + hw.x52 + jdk + cc.libgraal + bench.scala_dacapo_size_variants,
-    c.weekly                   + hw.x52 + jdk + cc.libgraal + bench.scala_dacapo_timing,
-    c.daily + c.opt_post_merge + hw.x52 + jdk + cc.libgraal + bench.renaissance + {unicorn_pull_request_benchmarking:: 'libgraal'},
-    c.daily + c.opt_post_merge + hw.x52 + jdk + cc.libgraal + bench.specjvm2008 + {unicorn_pull_request_benchmarking:: 'libgraal'},
-    c.weekly                   + hw.x52 + jdk + cc.libgraal + bench.specjbb2015,
-    c.weekly                   + hw.x52 + jdk + cc.libgraal + bench.specjbb2015_full_machine,
-    c.weekly                   + hw.x52 + jdk + cc.libgraal + bench.renaissance_0_11,
-    c.daily + c.opt_post_merge + hw.x52 + jdk + cc.libgraal + bench.awfy + {unicorn_pull_request_benchmarking:: 'libgraal'},
-    c.daily                    + hw.x52 + jdk + cc.libgraal + bench.microservice_benchmarks,
-    c.daily                    + hw.x52 + jdk + cc.libgraal + bench.renaissance_legacy,
-    c.daily                    + hw.x52 + jdk + cc.libgraal + bench.micros_graal_whitebox,
-    c.daily                    + hw.x52 + jdk + cc.libgraal + bench.micros_graal_dist,
-    c.daily                    + hw.x52 + jdk + cc.libgraal + bench.micros_misc_graal_dist,
-    c.daily                    + hw.x52 + jdk + cc.libgraal + bench.micros_shootout_graal_dist,
+    c.daily + c.opt_post_merge + hw.e3 + jdk + cc.libgraal + bench.dacapo + { unicorn_pull_request_benchmarking:: {name: 'libgraal', metrics: ['time']}},
+    c.weekly                   + hw.e3 + jdk + cc.libgraal + bench.dacapo_size_variants,
+    c.weekly                   + hw.e3 + jdk + cc.libgraal + bench.dacapo_timing,
+    c.daily + c.opt_post_merge + hw.e3 + jdk + cc.libgraal + bench.scala_dacapo + {unicorn_pull_request_benchmarking:: 'libgraal'},
+    c.weekly                   + hw.e3 + jdk + cc.libgraal + bench.scala_dacapo_size_variants,
+    c.weekly                   + hw.e3 + jdk + cc.libgraal + bench.scala_dacapo_timing,
+    c.daily + c.opt_post_merge + hw.e3 + jdk + cc.libgraal + bench.renaissance + {unicorn_pull_request_benchmarking:: 'libgraal'},
+    c.daily + c.opt_post_merge + hw.e3 + jdk + cc.libgraal + bench.specjvm2008 + {unicorn_pull_request_benchmarking:: 'libgraal'},
+    c.weekly                   + hw.e3 + jdk + cc.libgraal + bench.specjbb2015,
+    c.weekly                   + hw.e3 + jdk + cc.libgraal + bench.specjbb2015_full_machine,
+    c.weekly                   + hw.e3 + jdk + cc.libgraal + bench.renaissance_0_11,
+    c.daily + c.opt_post_merge + hw.e3 + jdk + cc.libgraal + bench.awfy + {unicorn_pull_request_benchmarking:: 'libgraal'},
+    c.daily                    + hw.e3 + jdk + cc.libgraal + bench.microservice_benchmarks,
+    c.daily                    + hw.e3 + jdk + cc.libgraal + bench.renaissance_legacy,
+    c.daily                    + hw.e3 + jdk + cc.libgraal + bench.micros_graal_whitebox,
+    c.daily                    + hw.e3 + jdk + cc.libgraal + bench.micros_graal_dist,
+    c.daily                    + hw.e3 + jdk + cc.libgraal + bench.micros_misc_graal_dist,
+    c.daily                    + hw.e3 + jdk + cc.libgraal + bench.micros_shootout_graal_dist,
     ]
   for jdk in cc.bench_jdks
   ]),
 
   local profiling_builds = std.flattenArrays([
     [
-    c.weekly + hw.x52 + jdk + cc.libgraal + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
-    c.weekly + hw.x52 + jdk + cc.libgraal + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" }
+    c.monthly + hw.e3 + jdk + cc.libgraal + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
+    c.monthly + hw.e3 + jdk + cc.libgraal + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" }
     ]
   for jdk in cc.bench_jdks
   for suite in bench.groups.profiled_suites
   ]),
 
   local weekly_amd64_forks_builds = std.flattenArrays([
-    bc.generate_fork_builds(c.weekly  + hw.x52  + jdk + cc.libgraal + suite, subdir='compiler') +
-    bc.generate_fork_builds(c.monthly + hw.x52  + jdk + cc.jargraal + suite, subdir='compiler')
+    bc.generate_fork_builds(c.weekly  + hw.e3  + jdk + cc.libgraal + suite, subdir='compiler') +
+    bc.generate_fork_builds(c.monthly + hw.e3  + jdk + cc.jargraal + suite, subdir='compiler')
   for jdk in cc.bench_jdks
   for suite in bench.groups.weekly_forks_suites
   ]),
@@ -63,7 +63,7 @@
   ],
 
   local zgc_builds = [
-    c.weekly + hw.x52 + jdk + cc.libgraal + cc.zgc_mode + suite,
+    c.weekly + hw.e3 + jdk + cc.libgraal + cc.zgc_mode + suite,
   for jdk in cc.bench_jdks
   for suite in bench.groups.main_suites + [bench.specjbb2015]
   ],
@@ -76,13 +76,13 @@
   ],
 
   local no_tiered_builds = [
-    c.weekly + hw.x52 + jdk + cc.libgraal + cc.no_tiered_comp + suite,
+    c.monthly + hw.e3 + jdk + cc.libgraal + cc.no_tiered_comp + suite,
   for jdk in cc.bench_jdks
   for suite in bench.groups.main_suites
   ],
 
   local no_profile_info_builds = [
-    c.weekly + hw.x52 + jdk + cc.libgraal + cc.no_profile_info + suite,
+    c.monthly + hw.e3 + jdk + cc.libgraal + cc.no_profile_info + suite,
   for jdk in cc.bench_jdks
   for suite in bench.groups.main_suites
   ],

--- a/compiler/ci/ci_common/benchmark-suites.libsonnet
+++ b/compiler/ci/ci_common/benchmark-suites.libsonnet
@@ -26,7 +26,7 @@
 
   // suite definitions
   // *****************
-  awfy: cc.compiler_benchmark + c.heap.small + {
+  awfy: cc.compiler_benchmark + c.heap.small + bc.bench_max_threads + {
     suite:: "awfy",
     run+: [
       self.benchmark_cmd + ["awfy:*", "--"] + self.extra_vm_args
@@ -38,7 +38,7 @@
     max_jdk_version:: null
   },
 
-  dacapo: cc.compiler_benchmark + c.heap.default + {
+  dacapo: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: "dacapo",
     run+: [
       self.benchmark_cmd + ["dacapo:*", "--"] + self.extra_vm_args
@@ -50,7 +50,7 @@
     max_jdk_version:: null
   },
 
-  dacapo_size_variants: cc.compiler_benchmark + c.heap.default + {
+  dacapo_size_variants: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: "dacapo-size-variants",
     run+: [
       self.benchmark_cmd + ["dacapo-small:*", "--"] + self.extra_vm_args,
@@ -76,7 +76,7 @@
     max_jdk_version:: null
   },
 
-  scala_dacapo: cc.compiler_benchmark + c.heap.default + {
+  scala_dacapo: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: "scala-dacapo",
     run+: [
       self.benchmark_cmd + ["scala-dacapo:*", "--"] + self.extra_vm_args
@@ -88,7 +88,7 @@
     max_jdk_version:: null
   },
 
-  scala_dacapo_size_variants: cc.compiler_benchmark + c.heap.default + {
+  scala_dacapo_size_variants: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: "scala-dacapo-size-variants",
     run+: [
       self.benchmark_cmd + ["scala-dacapo-tiny:*", "--"] + self.extra_vm_args,
@@ -119,7 +119,7 @@
     max_jdk_version:: null
   },
 
-  renaissance_template(suite_version=null, suite_name="renaissance", max_jdk_version=null):: cc.compiler_benchmark + c.heap.default + {
+  renaissance_template(suite_version=null, suite_name="renaissance", max_jdk_version=null):: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: suite_name,
     local suite_version_args = if suite_version != null then ["--bench-suite-version=" + suite_version] else [],
     run+: [
@@ -208,7 +208,7 @@
   },
 
   // Microservice benchmarks
-  microservice_benchmarks: cc.compiler_benchmark + {
+  microservice_benchmarks: cc.compiler_benchmark + bc.bench_no_thread_cap + {  # no thread cap here since hwloc is handled at the mx level for microservices
     suite:: "microservices",
     packages+: {
       "pip:psutil": "==5.8.0"
@@ -221,15 +221,7 @@
     local hwlocBind_16C_32T = ["--hwloc-bind=--cpubind node:0.core:0-15.pu:0-1 --membind node:0"],
     run+: [
       # shopcart-wrk
-      self.benchmark_cmd + ["shopcart-wrk:mixed-tiny"]                   + hwlocBind_1C_1T   + ["--"] + self.extra_vm_args + ["-Xms32m",   "-Xmx112m",  "-XX:ActiveProcessorCount=1",  "-XX:MaxDirectMemorySize=256m"],
-      bench_upload,
-      self.benchmark_cmd + ["shopcart-wrk:mixed-small"]                  + hwlocBind_2C_2T   + ["--"] + self.extra_vm_args + ["-Xms64m",   "-Xmx224m",  "-XX:ActiveProcessorCount=2",  "-XX:MaxDirectMemorySize=512m"],
-      bench_upload,
-      self.benchmark_cmd + ["shopcart-wrk:mixed-medium"]                 + hwlocBind_4C_4T   + ["--"] + self.extra_vm_args + ["-Xms128m",  "-Xmx512m",  "-XX:ActiveProcessorCount=4",  "-XX:MaxDirectMemorySize=1024m"],
-      bench_upload,
       self.benchmark_cmd + ["shopcart-wrk:mixed-large"]                  + hwlocBind_16C_16T + ["--"] + self.extra_vm_args + ["-Xms512m",  "-Xmx3072m", "-XX:ActiveProcessorCount=16", "-XX:MaxDirectMemorySize=4096m"],
-      bench_upload,
-      self.benchmark_cmd + ["shopcart-wrk:mixed-huge"]                   + hwlocBind_16C_32T + ["--"] + self.extra_vm_args + ["-Xms1024m", "-Xmx8192m", "-XX:ActiveProcessorCount=32", "-XX:MaxDirectMemorySize=8192m"],
       bench_upload,
 
       # tika-wrk odt
@@ -257,8 +249,6 @@
       bench_upload,
       self.benchmark_cmd + ["petclinic-wrk:mixed-large"]                 + hwlocBind_16C_16T + ["--"] + self.extra_vm_args + ["-Xms320m",  "-Xmx1280m", "-XX:ActiveProcessorCount=16"],
       bench_upload,
-      self.benchmark_cmd + ["petclinic-wrk:mixed-huge"]                  + hwlocBind_16C_32T + ["--"] + self.extra_vm_args + ["-Xms640m",  "-Xmx3072m", "-XX:ActiveProcessorCount=32"],
-      bench_upload,
 
       # helloworld-wrk
       self.benchmark_cmd + ["micronaut-helloworld-wrk:helloworld"]       + hwlocBind_1C_1T   + ["--"] + self.extra_vm_args + ["-Xms8m",    "-Xmx64m",   "-XX:ActiveProcessorCount=1", "-XX:MaxDirectMemorySize=256m"],
@@ -275,7 +265,7 @@
   },
 
   // JMH microbenchmarks
-  micros_graal_whitebox: cc.compiler_benchmark + c.heap.default + {
+  micros_graal_whitebox: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: "micros-graal-whitebox",
     run+: [
       self.benchmark_cmd + ["jmh-whitebox:*", "--"] + self.extra_vm_args
@@ -285,7 +275,7 @@
     max_jdk_version:: null
   },
 
-  micros_graal_dist: cc.compiler_benchmark + c.heap.default + {
+  micros_graal_dist: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: "micros-graal-dist",
     run+: [
       self.benchmark_cmd + ["jmh-dist:GRAAL_COMPILER_MICRO_BENCHMARKS", "--"] + self.extra_vm_args
@@ -295,7 +285,7 @@
     max_jdk_version:: null
   },
 
-  micros_misc_graal_dist: cc.compiler_benchmark + c.heap.default + {
+  micros_misc_graal_dist: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: "micros-misc-graal-dist",
     run+: [
       self.benchmark_cmd + ["jmh-dist:GRAAL_BENCH_MISC", "--"] + self.extra_vm_args
@@ -305,7 +295,7 @@
     max_jdk_version:: null
   },
 
-  micros_shootout_graal_dist: cc.compiler_benchmark + c.heap.default {
+  micros_shootout_graal_dist: cc.compiler_benchmark + c.heap.default + bc.bench_max_threads + {
     suite:: "micros-shootout-graal-dist",
     run+: [
       self.benchmark_cmd + ["jmh-dist:GRAAL_BENCH_SHOOTOUT", "--"] + self.extra_vm_args

--- a/compiler/ci/ci_common/benchmark-suites.libsonnet
+++ b/compiler/ci/ci_common/benchmark-suites.libsonnet
@@ -241,12 +241,6 @@
       bench_upload,
 
       # petclinic-wrk
-      self.benchmark_cmd + ["petclinic-wrk:mixed-tiny"]                  + hwlocBind_1C_1T   + ["--"] + self.extra_vm_args + ["-Xms32m",   "-Xmx100m",  "-XX:ActiveProcessorCount=1"],
-      bench_upload,
-      self.benchmark_cmd + ["petclinic-wrk:mixed-small"]                 + hwlocBind_2C_2T   + ["--"] + self.extra_vm_args + ["-Xms40m",   "-Xmx144m",  "-XX:ActiveProcessorCount=2"],
-      bench_upload,
-      self.benchmark_cmd + ["petclinic-wrk:mixed-medium"]                + hwlocBind_4C_4T   + ["--"] + self.extra_vm_args + ["-Xms80m",   "-Xmx256m",  "-XX:ActiveProcessorCount=4"],
-      bench_upload,
       self.benchmark_cmd + ["petclinic-wrk:mixed-large"]                 + hwlocBind_16C_16T + ["--"] + self.extra_vm_args + ["-Xms320m",  "-Xmx1280m", "-XX:ActiveProcessorCount=16"],
       bench_upload,
 

--- a/compiler/ci/ci_common/compiler-common.libsonnet
+++ b/compiler/ci/ci_common/compiler-common.libsonnet
@@ -66,7 +66,6 @@
       "${BENCH_RESULTS_FILE_PATH}",
       "--machine-name=${MACHINE_NAME}"] +
       (if std.objectHasAll(self.environment, 'MX_TRACKER') then ["--tracker=" + self.environment['MX_TRACKER']] else ["--tracker=rss"]),
-    benchmark_cmd:: bench_common.hwlocIfNuma(self.should_use_hwloc, self.plain_benchmark_cmd, node=self.default_numa_node),
     min_heap_size:: if std.objectHasAll(self.environment, 'XMS') then ["-Xms${XMS}"] else [],
     max_heap_size:: if std.objectHasAll(self.environment, 'XMX') then ["-Xmx${XMX}"] else [],
     _WarnMissingIntrinsic:: true, # won't be needed after GR-34642

--- a/compiler/ci/ci_common/compiler-common.libsonnet
+++ b/compiler/ci/ci_common/compiler-common.libsonnet
@@ -66,6 +66,8 @@
       "${BENCH_RESULTS_FILE_PATH}",
       "--machine-name=${MACHINE_NAME}"] +
       (if std.objectHasAll(self.environment, 'MX_TRACKER') then ["--tracker=" + self.environment['MX_TRACKER']] else ["--tracker=rss"]),
+    restrict_threads:: null,  # can be overridden to restrict the benchmark to the given number of threads. If null, will use one full NUMA node
+    benchmark_cmd:: if self.should_use_hwloc then bench_common.hwloc_cmd(self.plain_benchmark_cmd, self.restrict_threads, self.default_numa_node, self.hyperthreading, self.threads_per_node) else self.plain_benchmark_cmd,
     min_heap_size:: if std.objectHasAll(self.environment, 'XMS') then ["-Xms${XMS}"] else [],
     max_heap_size:: if std.objectHasAll(self.environment, 'XMX') then ["-Xmx${XMX}"] else [],
     _WarnMissingIntrinsic:: true, # won't be needed after GR-34642

--- a/compiler/ci/ci_includes/baseline-benchmarks.jsonnet
+++ b/compiler/ci/ci_includes/baseline-benchmarks.jsonnet
@@ -18,10 +18,10 @@
 
   local hotspot_profiling_builds = std.flattenArrays([
     [
-    c.weekly + hw.x52  + cc.latest_jdk + cc.c2 + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
-    c.weekly + hw.a12c + cc.latest_jdk + cc.c2 + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
-    c.weekly + hw.x52  + cc.latest_jdk + cc.c2 + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" },
-    c.weekly + hw.a12c + cc.latest_jdk + cc.c2 + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" }
+    c.monthly + hw.x52  + cc.latest_jdk + cc.c2 + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
+    c.monthly + hw.a12c + cc.latest_jdk + cc.c2 + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
+    c.monthly + hw.x52  + cc.latest_jdk + cc.c2 + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" },
+    c.monthly + hw.a12c + cc.latest_jdk + cc.c2 + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" }
     ]
   for suite in bench.groups.profiled_suites
   ]),
@@ -37,23 +37,16 @@
   for suite in bench.groups.weekly_forks_suites
   ]),
 
-  local daily_economy_builds = [
-      c.daily + hw.x52 + jdk + cc.libgraal + cc.economy_mode + suite
-    for jdk in cc.bench_jdks
-    for suite in bench.groups.main_suites
-  ],
-
-  local weekly_economy_builds = [
-      c.weekly + hw.x52 + jdk + cc.libgraal + cc.economy_mode + suite
+  local economy_builds = [
+      c.weekly + hw.e3 + jdk + cc.libgraal + cc.economy_mode + suite
     for jdk in cc.bench_jdks
     for suite in bench.groups.all_but_main_suites
   ],
-
   local no_tiered_builds = std.flattenArrays([
     [
-    c.weekly + hw.x52 + jdk + cc.c1                                             + suite,
-    c.weekly + hw.x52 + jdk + cc.c2                         + cc.no_tiered_comp + suite,
-    c.weekly + hw.x52 + jdk + cc.libgraal + cc.economy_mode + cc.no_tiered_comp + suite
+    c.monthly + hw.x52 + jdk + cc.c1                                             + suite,
+    c.monthly + hw.x52 + jdk + cc.c2                         + cc.no_tiered_comp + suite,
+    c.monthly + hw.x52 + jdk + cc.libgraal + cc.economy_mode + cc.no_tiered_comp + suite
     ]
   for jdk in cc.bench_jdks
   for suite in bench.groups.main_suites
@@ -61,21 +54,21 @@
 
   local gc_variants_builds = std.flattenArrays([
     [
-    c.weekly + hw.x52 + jdk + cc.c2                         + cc.zgc_mode + suite,
+    c.monthly + hw.x52 + jdk + cc.c2                         + cc.zgc_mode + suite,
     ]
   for jdk in cc.bench_jdks
   for suite in bench.groups.main_suites
   ]) + std.flattenArrays([
     [
-    c.weekly + hw.x52 + jdk + cc.c2                         + cc.serialgc_mode + bench.microservice_benchmarks,
-    c.weekly + hw.x52 + jdk + cc.c2                         + cc.pargc_mode + bench.microservice_benchmarks,
-    c.weekly + hw.x52 + jdk + cc.c2                         + cc.zgc_mode + bench.microservice_benchmarks,
-    c.weekly + hw.x52 + jdk + cc.c2                         + cc.gen_zgc_mode + bench.microservice_benchmarks,
+    c.monthly + hw.x52 + jdk + cc.c2                         + cc.serialgc_mode + bench.microservice_benchmarks,
+    c.monthly + hw.x52 + jdk + cc.c2                         + cc.pargc_mode    + bench.microservice_benchmarks,
+    c.monthly + hw.x52 + jdk + cc.c2                         + cc.zgc_mode      + bench.microservice_benchmarks,
+    c.monthly + hw.x52 + jdk + cc.c2                         + cc.gen_zgc_mode  + bench.microservice_benchmarks,
     ]
   for jdk in cc.bench_jdks
   ]),
   local all_builds = hotspot_amd64_builds + hotspot_aarch64_builds + hotspot_profiling_builds +
-    weekly_forks_amd64_builds + weekly_forks_aarch64_builds + daily_economy_builds + weekly_economy_builds + no_tiered_builds + gc_variants_builds,
+    weekly_forks_amd64_builds + weekly_forks_aarch64_builds + economy_builds + no_tiered_builds + gc_variants_builds,
   local filtered_builds = [b for b in all_builds if b.is_jdk_supported(b.jdk_version) && b.is_arch_supported(b.arch)],
 
   // adds a "defined_in" field to all builds mentioning the location of this current file

--- a/compiler/ci/ci_includes/baseline-benchmarks.jsonnet
+++ b/compiler/ci/ci_includes/baseline-benchmarks.jsonnet
@@ -6,7 +6,7 @@
   local hw = bc.bench_hw,
 
   local hotspot_amd64_builds = [
-    c.weekly + hw.x52 + jdk + cc.c2 + suite
+    c.weekly + hw.e3 + jdk + cc.c2 + suite
   for jdk in cc.bench_jdks
   for suite in bench.groups.all_suites
   ],
@@ -18,16 +18,16 @@
 
   local hotspot_profiling_builds = std.flattenArrays([
     [
-    c.monthly + hw.x52  + cc.latest_jdk + cc.c2 + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
+    c.monthly + hw.e3  + cc.latest_jdk + cc.c2 + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
     c.monthly + hw.a12c + cc.latest_jdk + cc.c2 + suite + cc.enable_profiling   + { job_prefix:: "bench-compiler-profiling" },
-    c.monthly + hw.x52  + cc.latest_jdk + cc.c2 + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" },
+    c.monthly + hw.e3  + cc.latest_jdk + cc.c2 + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" },
     c.monthly + hw.a12c + cc.latest_jdk + cc.c2 + suite + cc.footprint_tracking + { job_prefix:: "bench-compiler-footprint" }
     ]
   for suite in bench.groups.profiled_suites
   ]),
 
   local weekly_forks_amd64_builds = std.flattenArrays([
-    bc.generate_fork_builds(c.weekly + hw.x52 + jdk + cc.c2 + suite)
+    bc.generate_fork_builds(c.weekly + hw.e3 + jdk + cc.c2 + suite)
   for jdk in cc.bench_jdks
   for suite in bench.groups.weekly_forks_suites
   ]),
@@ -39,14 +39,14 @@
 
   local economy_builds = [
       c.weekly + hw.e3 + jdk + cc.libgraal + cc.economy_mode + suite
-    for jdk in cc.bench_jdks
-    for suite in bench.groups.all_but_main_suites
+    for jdk in cc.product_jdks
+    for suite in bench.groups.main_suites
   ],
   local no_tiered_builds = std.flattenArrays([
     [
-    c.monthly + hw.x52 + jdk + cc.c1                                             + suite,
-    c.monthly + hw.x52 + jdk + cc.c2                         + cc.no_tiered_comp + suite,
-    c.monthly + hw.x52 + jdk + cc.libgraal + cc.economy_mode + cc.no_tiered_comp + suite
+    c.monthly + hw.e3 + jdk + cc.c1                                             + suite,
+    c.monthly + hw.e3 + jdk + cc.c2                         + cc.no_tiered_comp + suite,
+    c.monthly + hw.e3 + jdk + cc.libgraal + cc.economy_mode + cc.no_tiered_comp + suite
     ]
   for jdk in cc.bench_jdks
   for suite in bench.groups.main_suites
@@ -54,16 +54,16 @@
 
   local gc_variants_builds = std.flattenArrays([
     [
-    c.monthly + hw.x52 + jdk + cc.c2                         + cc.zgc_mode + suite,
+    c.monthly + hw.e3 + jdk + cc.c2                         + cc.zgc_mode + suite,
     ]
   for jdk in cc.bench_jdks
   for suite in bench.groups.main_suites
   ]) + std.flattenArrays([
     [
-    c.monthly + hw.x52 + jdk + cc.c2                         + cc.serialgc_mode + bench.microservice_benchmarks,
-    c.monthly + hw.x52 + jdk + cc.c2                         + cc.pargc_mode    + bench.microservice_benchmarks,
-    c.monthly + hw.x52 + jdk + cc.c2                         + cc.zgc_mode      + bench.microservice_benchmarks,
-    c.monthly + hw.x52 + jdk + cc.c2                         + cc.gen_zgc_mode  + bench.microservice_benchmarks,
+    c.monthly + hw.e3 + jdk + cc.c2                         + cc.serialgc_mode + bench.microservice_benchmarks,
+    c.monthly + hw.e3 + jdk + cc.c2                         + cc.pargc_mode    + bench.microservice_benchmarks,
+    c.monthly + hw.e3 + jdk + cc.c2                         + cc.zgc_mode      + bench.microservice_benchmarks,
+    c.monthly + hw.e3 + jdk + cc.c2                         + cc.gen_zgc_mode  + bench.microservice_benchmarks,
     ]
   for jdk in cc.bench_jdks
   ]),

--- a/compiler/ci/ci_includes/baseline-benchmarks.jsonnet
+++ b/compiler/ci/ci_includes/baseline-benchmarks.jsonnet
@@ -39,7 +39,7 @@
 
   local economy_builds = [
       c.weekly + hw.e3 + jdk + cc.libgraal + cc.economy_mode + suite
-    for jdk in cc.product_jdks
+    for jdk in cc.bench_jdks
     for suite in bench.groups.main_suites
   ],
   local no_tiered_builds = std.flattenArrays([

--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/FixedGuardSimplificationTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/FixedGuardSimplificationTest.java
@@ -43,6 +43,7 @@ import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.code.InvalidInstalledCodeException;
 import jdk.vm.ci.meta.DeoptimizationAction;
 import jdk.vm.ci.meta.DeoptimizationReason;
+import jdk.vm.ci.meta.SpeculationLog;
 
 /**
  * Tests that correct removal of always deoptimizing {@link FixedGuardNode}s in the presence of
@@ -76,6 +77,11 @@ public class FixedGuardSimplificationTest extends GraalCompilerTest {
             A ba = b.a;
             GraalDirectives.blackhole(ba);
         }
+    }
+
+    @Override
+    protected SpeculationLog getSpeculationLog() {
+        return getCodeCache().createSpeculationLog();
     }
 
     @Override

--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/FixedGuardSimplificationTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/FixedGuardSimplificationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.test;
+
+import org.junit.Test;
+
+import org.graalvm.compiler.api.directives.GraalDirectives;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.nodes.FixedGuardNode;
+import org.graalvm.compiler.nodes.GraphState;
+import org.graalvm.compiler.nodes.PiNode;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.java.LoadFieldNode;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.BasePhase;
+import org.graalvm.compiler.phases.tiers.HighTierContext;
+import org.graalvm.compiler.phases.tiers.Suites;
+import org.graalvm.compiler.virtual.phases.ea.FinalPartialEscapePhase;
+import jdk.vm.ci.code.InstalledCode;
+import jdk.vm.ci.code.InvalidInstalledCodeException;
+import jdk.vm.ci.meta.DeoptimizationAction;
+import jdk.vm.ci.meta.DeoptimizationReason;
+
+/**
+ * Tests that correct removal of always deoptimizing {@link FixedGuardNode}s in the presence of
+ * floating reads. This test modifies the graph after PEA to introduce a {@link FixedGuardNode} in a
+ * branch which is dominated by another {@link FixedGuardNode} with the inverted condition.
+ * Replacing the always-deopt guard must ensure a proper cleanup of all attached floating reads.
+ * This is tested by a floating read for which the removed guard ensures non-nullness of the read
+ * object. If this read would survive the removal of the guard, a segfault would be triggered. The
+ * guard branch is deleted in midtier after conditional elimination.
+ */
+public class FixedGuardSimplificationTest extends GraalCompilerTest {
+
+    public static class A {
+        B b;
+
+        public A(B b) {
+            this.b = b;
+        }
+    }
+
+    public static class B {
+        A a;
+    }
+
+    public static void snippet(A a, A a2, int x) {
+        guardingNull(a);
+        if (x == 0) {
+            // a2 is replaced by a1 after FinalPEA
+            guardingNonNull(a2);
+            B b = a.b;
+            A ba = b.a;
+            GraalDirectives.blackhole(ba);
+        }
+    }
+
+    @Override
+    protected Suites createSuites(OptionValues opts) {
+        Suites s = super.createSuites(opts);
+        s.getHighTier().findPhase(FinalPartialEscapePhase.class).add(new BasePhase<HighTierContext>() {
+
+            @Override
+            protected void run(StructuredGraph graph, HighTierContext context) {
+                FixedGuardNode guard = graph.getNodes().filter(FixedGuardNode.class).first();
+                FixedGuardNode placeholderGuard = graph.getNodes().filter(FixedGuardNode.class).snapshot().get(1);
+
+                /*
+                 * Makes the inner guard use the inverted condition of the dominating, outer guard
+                 * and adds the corresponding Pi. This can happen during PartialEscapeAnalysis.
+                 */
+                placeholderGuard.setCondition(guard.getCondition(), true);
+                ValueNode nullProven = (ValueNode) guard.getCondition().asNode().inputs().first();
+                PiNode pi = (PiNode) graph.addWithoutUnique(PiNode.create(nullProven, StampFactory.objectNonNull(), placeholderGuard));
+                LoadFieldNode lf = graph.getNodes().filter(LoadFieldNode.class).first();
+                lf.setObject(pi);
+            }
+
+            @Override
+            public java.util.Optional<NotApplicable> notApplicableTo(GraphState graphState) {
+                return ALWAYS_APPLICABLE;
+            }
+        });
+        return s;
+    }
+
+    private static <T> T guardingNull(T value) {
+        if (value != null) {
+            GraalDirectives.deoptimize(DeoptimizationAction.InvalidateRecompile, DeoptimizationReason.UnreachedCode, true);
+        }
+        return value;
+    }
+
+    private static <T> T guardingNonNull(T value) {
+        if (value == null) {
+            GraalDirectives.deoptimize(DeoptimizationAction.InvalidateRecompile, DeoptimizationReason.UnreachedCode, true);
+        }
+        return value;
+    }
+
+    @Test
+    public void test() throws InvalidInstalledCodeException {
+        InstalledCode code = getCode(getResolvedJavaMethod("snippet"));
+        boolean exceptionSeen = false;
+        try {
+            code.executeVarargs(null, new A(new B()), 0);
+        } catch (NullPointerException npe) {
+            exceptionSeen = true;
+        }
+        assert exceptionSeen : "Test expects a NPE to be thrown!";
+        assert !code.isValid() : "Test expects the code to have deopted!";
+    }
+}

--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/LoopUnswitchTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/LoopUnswitchTest.java
@@ -27,7 +27,6 @@ package org.graalvm.compiler.core.test;
 import java.util.List;
 
 import org.graalvm.collections.EconomicMap;
-<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/LoopUnswitchTest.java
 import org.graalvm.compiler.api.directives.GraalDirectives;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.debug.DebugDumpScope;
@@ -44,25 +43,6 @@ import org.graalvm.compiler.nodes.loop.LoopPolicies;
 import org.graalvm.compiler.phases.common.CanonicalizerPhase;
 import org.junit.Assert;
 import org.junit.Test;
-=======
-import org.junit.Assert;
-import org.junit.Test;
-
-import jdk.graal.compiler.api.directives.GraalDirectives;
-import jdk.graal.compiler.debug.DebugContext;
-import jdk.graal.compiler.debug.DebugDumpScope;
-import jdk.graal.compiler.loop.phases.LoopUnswitchingPhase;
-import jdk.graal.compiler.nodes.ControlSplitNode;
-import jdk.graal.compiler.nodes.IfNode;
-import jdk.graal.compiler.nodes.StructuredGraph;
-import jdk.graal.compiler.nodes.StructuredGraph.AllowAssumptions;
-import jdk.graal.compiler.nodes.ValueNode;
-import jdk.graal.compiler.nodes.extended.SwitchNode;
-import jdk.graal.compiler.nodes.loop.DefaultLoopPolicies;
-import jdk.graal.compiler.nodes.loop.LoopEx;
-import jdk.graal.compiler.nodes.loop.LoopPolicies;
-import jdk.graal.compiler.phases.common.CanonicalizerPhase;
->>>>>>> c5586894366 (Add epsilon to more floating-point probability comparisons):compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/core/test/LoopUnswitchTest.java
 
 public class LoopUnswitchTest extends GraalCompilerTest {
 

--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/LoopUnswitchTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/LoopUnswitchTest.java
@@ -27,6 +27,7 @@ package org.graalvm.compiler.core.test;
 import java.util.List;
 
 import org.graalvm.collections.EconomicMap;
+<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/LoopUnswitchTest.java
 import org.graalvm.compiler.api.directives.GraalDirectives;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.debug.DebugDumpScope;
@@ -43,6 +44,25 @@ import org.graalvm.compiler.nodes.loop.LoopPolicies;
 import org.graalvm.compiler.phases.common.CanonicalizerPhase;
 import org.junit.Assert;
 import org.junit.Test;
+=======
+import org.junit.Assert;
+import org.junit.Test;
+
+import jdk.graal.compiler.api.directives.GraalDirectives;
+import jdk.graal.compiler.debug.DebugContext;
+import jdk.graal.compiler.debug.DebugDumpScope;
+import jdk.graal.compiler.loop.phases.LoopUnswitchingPhase;
+import jdk.graal.compiler.nodes.ControlSplitNode;
+import jdk.graal.compiler.nodes.IfNode;
+import jdk.graal.compiler.nodes.StructuredGraph;
+import jdk.graal.compiler.nodes.StructuredGraph.AllowAssumptions;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.extended.SwitchNode;
+import jdk.graal.compiler.nodes.loop.DefaultLoopPolicies;
+import jdk.graal.compiler.nodes.loop.LoopEx;
+import jdk.graal.compiler.nodes.loop.LoopPolicies;
+import jdk.graal.compiler.phases.common.CanonicalizerPhase;
+>>>>>>> c5586894366 (Add epsilon to more floating-point probability comparisons):compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/core/test/LoopUnswitchTest.java
 
 public class LoopUnswitchTest extends GraalCompilerTest {
 
@@ -474,6 +494,46 @@ public class LoopUnswitchTest extends GraalCompilerTest {
     public void test05() {
         final StructuredGraph graph = parseEager("manySwitch", AllowAssumptions.NO);
         CanonicalizerPhase canonicalizer = createCanonicalizerPhase();
+        new LoopUnswitchingPhase(new DefaultLoopPolicies(), canonicalizer).apply(graph, getDefaultHighTierContext());
+    }
+
+    static final double ULP = Math.ulp(0.25);
+
+    /**
+     * Simulate a profile that due to floating imprecision has branch probabilities summing to the
+     * next floating point number after 1.
+     */
+    public static int testImpreciseProfileSnippet(int a) {
+        int sum = 0;
+        for (int i = 0; i < 1000; i++) {
+            switch (a) {
+                case 0:
+                    GraalDirectives.injectSwitchCaseProbability(0.25);
+                    sum += 1;
+                    break;
+                case 1:
+                    GraalDirectives.injectSwitchCaseProbability(0.25);
+                    sum += 2;
+                    break;
+                case 2:
+                    GraalDirectives.injectSwitchCaseProbability(0.25);
+                    sum += 3;
+                    break;
+                default:
+                    GraalDirectives.injectSwitchCaseProbability(0.25 + ULP);
+                    sum += a;
+                    break;
+            }
+        }
+        return sum;
+    }
+
+    @Test
+    public void testImpreciseProfile() {
+        final StructuredGraph graph = parseEager("testImpreciseProfileSnippet", AllowAssumptions.NO);
+        CanonicalizerPhase canonicalizer = createCanonicalizerPhase();
+        // Apply canonicalizer to inject switch probabilities
+        canonicalizer.apply(graph, getDefaultHighTierContext());
         new LoopUnswitchingPhase(new DefaultLoopPolicies(), canonicalizer).apply(graph, getDefaultHighTierContext());
     }
 }

--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/replacements/test/NarrowCompareUnsignedTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/replacements/test/NarrowCompareUnsignedTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.replacements.test;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import org.graalvm.compiler.core.test.GraalCompilerTest;
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.AndNode;
+import org.graalvm.compiler.nodes.calc.IntegerNormalizeCompareNode;
+import org.graalvm.compiler.nodes.calc.NarrowNode;
+import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
+import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
+import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugins;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+/**
+ * Tests for {@link IntegerNormalizeCompareNode} applied to subword integers.
+ */
+public class NarrowCompareUnsignedTest extends GraalCompilerTest {
+
+    public static int narrowCompareUnsignedByte(int x, int y) {
+        /*
+         * This expression doesn't quite produce the graph shape we want: The narrows feed into sign
+         * extensions that feed into the actual compare. We want to test the compare when applied to
+         * the actual narrows. It's possible but fairly difficult to produce that graph shape in
+         * practice. Therefore we intrinsify this method to get what we want.
+         */
+        return Integer.compareUnsigned((byte) x, (byte) y);
+    }
+
+    public static int narrowCompareUnsignedShort(int x, int y) {
+        return Integer.compareUnsigned((short) x, (short) y);
+    }
+
+    public static int narrowCompareUnsignedChar(int x, int y) {
+        return Integer.compareUnsigned((char) x, (char) y);
+    }
+
+    @Override
+    protected void registerInvocationPlugins(InvocationPlugins invocationPlugins) {
+        InvocationPlugins.Registration r = new InvocationPlugins.Registration(invocationPlugins, NarrowCompareUnsignedTest.class);
+        r.register(new InvocationPlugin.InlineOnlyInvocationPlugin("narrowCompareUnsignedByte", int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {
+                ValueNode narrowX = NarrowNode.create(x, Byte.SIZE, NodeView.DEFAULT);
+                ValueNode narrowY = NarrowNode.create(y, Byte.SIZE, NodeView.DEFAULT);
+                b.addPush(JavaKind.Int, IntegerNormalizeCompareNode.create(narrowX, narrowY, true, JavaKind.Int, b.getConstantReflection()));
+                return true;
+            }
+        });
+        r.register(new InvocationPlugin.InlineOnlyInvocationPlugin("narrowCompareUnsignedShort", int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {
+                ValueNode narrowX = NarrowNode.create(x, Short.SIZE, NodeView.DEFAULT);
+                ValueNode narrowY = NarrowNode.create(y, Short.SIZE, NodeView.DEFAULT);
+                b.addPush(JavaKind.Int, IntegerNormalizeCompareNode.create(narrowX, narrowY, true, JavaKind.Int, b.getConstantReflection()));
+                return true;
+            }
+        });
+        r.register(new InvocationPlugin.InlineOnlyInvocationPlugin("narrowCompareUnsignedChar", int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {
+                int unsignedMask = 0xffff;
+                ValueNode maskedX = AndNode.create(x, ConstantNode.forInt(unsignedMask), NodeView.DEFAULT);
+                ValueNode maskedY = AndNode.create(y, ConstantNode.forInt(unsignedMask), NodeView.DEFAULT);
+                ValueNode narrowX = NarrowNode.create(maskedX, Character.SIZE, NodeView.DEFAULT);
+                ValueNode narrowY = NarrowNode.create(maskedY, Character.SIZE, NodeView.DEFAULT);
+                b.addPush(JavaKind.Int, IntegerNormalizeCompareNode.create(narrowX, narrowY, true, JavaKind.Int, b.getConstantReflection()));
+                return true;
+            }
+        });
+        super.registerInvocationPlugins(invocationPlugins);
+    }
+
+    private static final int[] TEST_VALUES = new int[]{0, 40, Byte.MAX_VALUE, Byte.MAX_VALUE + 40, Short.MAX_VALUE, Short.MAX_VALUE + 40, Character.MAX_VALUE, Character.MAX_VALUE + 40};
+
+    public static int byteVariableSnippet(int x, int y) {
+        return narrowCompareUnsignedByte(x, y);
+    }
+
+    @Test
+    public void byteVariable() {
+        Assume.assumeTrue("only test byte compare when supported on target", getLowerer().smallestCompareWidth() <= Byte.SIZE);
+        for (int x : TEST_VALUES) {
+            for (int y : TEST_VALUES) {
+                test("byteVariableSnippet", x, y);
+            }
+        }
+    }
+
+    public static int byteConstantSnippet(int x) {
+        return narrowCompareUnsignedByte(x, Byte.MAX_VALUE);
+    }
+
+    @Test
+    public void byteConstant() {
+        Assume.assumeTrue("only test byte compare when supported on target", getLowerer().smallestCompareWidth() <= Byte.SIZE);
+        for (int x : TEST_VALUES) {
+            test("byteConstantSnippet", x);
+        }
+    }
+
+    public static int shortVariableSnippet(int x, int y) {
+        return narrowCompareUnsignedShort(x, y);
+    }
+
+    @Test
+    public void shortVariable() {
+        Assume.assumeTrue("only test short compare when supported on target", getLowerer().smallestCompareWidth() <= Short.SIZE);
+        for (int x : TEST_VALUES) {
+            for (int y : TEST_VALUES) {
+                test("shortVariableSnippet", x, y);
+            }
+        }
+    }
+
+    public static int shortConstantSnippet(int x) {
+        return narrowCompareUnsignedShort(x, Short.MAX_VALUE);
+    }
+
+    @Test
+    public void shortConstant() {
+        Assume.assumeTrue("only test short compare when supported on target", getLowerer().smallestCompareWidth() <= Short.SIZE);
+        for (int x : TEST_VALUES) {
+            test("shortConstantSnippet", x);
+        }
+    }
+
+    public static int charVariableSnippet(int x, int y) {
+        return narrowCompareUnsignedChar(x, y);
+    }
+
+    @Test
+    public void charVariable() {
+        Assume.assumeTrue("only test char compare when supported on target", getLowerer().smallestCompareWidth() <= Character.SIZE);
+        for (int x : TEST_VALUES) {
+            for (int y : TEST_VALUES) {
+                test("charVariableSnippet", x, y);
+            }
+        }
+    }
+
+    public static int charConstantSnippet(int x) {
+        return narrowCompareUnsignedChar(x, Character.MAX_VALUE);
+    }
+
+    @Test
+    public void charConstant() {
+        Assume.assumeTrue("only test char compare when supported on target", getLowerer().smallestCompareWidth() <= Character.SIZE);
+        for (int x : TEST_VALUES) {
+            test("charConstantSnippet", x);
+        }
+    }
+}

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -688,7 +688,8 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
     }
 
     @Override
-    public Variable emitNormalizedUnsignedCompare(Value x, Value y) {
+    public Variable emitNormalizedUnsignedCompare(LIRKind compareKind, Value x, Value y) {
+        GraalError.guarantee(compareKind.getPlatformKind() == AArch64Kind.DWORD || compareKind.getPlatformKind() == AArch64Kind.QWORD, "unsupported subword comparison: %s", compareKind);
         Variable result = getLIRGen().newVariable(LIRKind.value(AArch64Kind.DWORD));
         getLIRGen().append(new AArch64NormalizedUnsignedCompareOp(result, asAllocatable(x), asAllocatable(y)));
         return result;

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -909,7 +909,8 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
     public ComplexMatchResult normalizedIntegerCompare(ValueNode x, ValueNode y, ConstantNode cm1, ConstantNode c0, ConstantNode c1) {
         if (cm1.getStackKind() == JavaKind.Int && cm1.asJavaConstant().asInt() == -1 && c0.getStackKind() == JavaKind.Int && c0.asJavaConstant().asInt() == 0 && c1.getStackKind() == JavaKind.Int &&
                         c1.asJavaConstant().asInt() == 1) {
-            return builder -> getArithmeticLIRGenerator().emitNormalizedUnsignedCompare(operand(x), operand(y));
+            LIRKind compareKind = gen.getLIRKind(x.stamp(NodeView.DEFAULT));
+            return builder -> getArithmeticLIRGenerator().emitNormalizedUnsignedCompare(compareKind, operand(x), operand(y));
         }
         return null;
     }

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
@@ -1690,9 +1690,9 @@ public class AMD64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implemen
     }
 
     @Override
-    public Variable emitNormalizedUnsignedCompare(Value x, Value y) {
+    public Variable emitNormalizedUnsignedCompare(LIRKind compareKind, Value x, Value y) {
         Variable result = getLIRGen().newVariable(LIRKind.value(AMD64Kind.DWORD));
-        getLIRGen().append(new AMD64NormalizedUnsignedCompareOp(result, asAllocatable(x), asAllocatable(y)));
+        getLIRGen().append(new AMD64NormalizedUnsignedCompareOp(result, compareKind, asAllocatable(x), asAllocatable(y)));
         return result;
     }
 }

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64NormalizedUnsignedCompareOp.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64NormalizedUnsignedCompareOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,18 @@
 package org.graalvm.compiler.lir.amd64;
 
 import static jdk.vm.ci.code.ValueUtil.asRegister;
+import static org.graalvm.compiler.asm.amd64.AMD64Assembler.AMD64BinaryArithmetic.CMP;
 import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.REG;
 
 import org.graalvm.compiler.asm.Label;
 import org.graalvm.compiler.asm.amd64.AMD64Assembler;
+import org.graalvm.compiler.asm.amd64.AMD64BaseAssembler;
 import org.graalvm.compiler.asm.amd64.AMD64MacroAssembler;
-import org.graalvm.compiler.debug.GraalError;
+import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.lir.LIRInstructionClass;
 import org.graalvm.compiler.lir.SyncPort;
 import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
 
-import jdk.vm.ci.amd64.AMD64Kind;
 import jdk.vm.ci.meta.AllocatableValue;
 
 /**
@@ -54,23 +55,22 @@ public class AMD64NormalizedUnsignedCompareOp extends AMD64LIRInstruction {
     @Use({REG}) protected AllocatableValue x;
     @Use({REG}) protected AllocatableValue y;
 
-    public AMD64NormalizedUnsignedCompareOp(AllocatableValue result, AllocatableValue x, AllocatableValue y) {
+    private final LIRKind compareKind;
+
+    public AMD64NormalizedUnsignedCompareOp(AllocatableValue result, LIRKind compareKind, AllocatableValue x, AllocatableValue y) {
         super(TYPE);
 
         this.result = result;
         this.x = x;
         this.y = y;
+        this.compareKind = compareKind;
     }
 
     @Override
     public void emitCode(CompilationResultBuilder crb, AMD64MacroAssembler masm) {
         Label done = new Label();
-        if (x.getPlatformKind() == AMD64Kind.DWORD) {
-            masm.cmpl(asRegister(x), asRegister(y));
-        } else {
-            GraalError.guarantee(x.getPlatformKind() == AMD64Kind.QWORD, "unsupported value kind %s", x.getPlatformKind());
-            masm.cmpq(asRegister(x), asRegister(y));
-        }
+        AMD64BaseAssembler.OperandSize size = AMD64BaseAssembler.OperandSize.get(compareKind.getPlatformKind());
+        CMP.getRMOpcode(size).emit(masm, size, asRegister(x), asRegister(y));
         masm.movl(asRegister(result), -1);
         masm.jccb(AMD64Assembler.ConditionFlag.Below, done);
         masm.setl(AMD64Assembler.ConditionFlag.NotEqual, asRegister(result));

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,7 +206,7 @@ public interface ArithmeticLIRGeneratorTool {
     }
 
     @SuppressWarnings("unused")
-    default Variable emitNormalizedUnsignedCompare(Value x, Value y) {
+    default Variable emitNormalizedUnsignedCompare(LIRKind compareKind, Value x, Value y) {
         throw GraalError.unimplemented("No specialized implementation available");
     }
 

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/FixedGuardNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/FixedGuardNode.java
@@ -40,6 +40,7 @@ import org.graalvm.compiler.nodes.spi.Lowerable;
 import org.graalvm.compiler.nodes.spi.LoweringTool;
 import org.graalvm.compiler.nodes.spi.SimplifierTool;
 import org.graalvm.compiler.nodes.spi.SwitchFoldable;
+import org.graalvm.compiler.nodes.util.GraphUtil;
 
 import jdk.vm.ci.meta.DeoptimizationAction;
 import jdk.vm.ci.meta.DeoptimizationReason;
@@ -77,14 +78,15 @@ public final class FixedGuardNode extends AbstractFixedGuardNode implements Lowe
         if (getCondition() instanceof LogicConstantNode) {
             LogicConstantNode c = (LogicConstantNode) getCondition();
             if (c.getValue() == isNegated()) {
-                FixedNode currentNext = this.next();
-                if (currentNext != null) {
-                    tool.deleteBranch(currentNext);
-                }
-
+                /*
+                 * The guard will always deoptimize. Replace the guard and the remaining branch with
+                 * the corresponding deopt.
+                 */
                 DeoptimizeNode deopt = graph().add(new DeoptimizeNode(getAction(), getReason(), getSpeculation()));
                 deopt.setStateBefore(stateBefore());
-                setNext(deopt);
+                predecessor().replaceFirstSuccessor(this, deopt);
+                GraphUtil.killCFG(this);
+                return;
             }
             this.replaceAtUsages(null);
             graph().removeFixed(this);

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/IfNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/IfNode.java
@@ -175,8 +175,8 @@ public final class IfNode extends ControlSplitNode implements Simplifiable, LIRL
 
     public void setTrueSuccessorProbability(BranchProbabilityData profileData) {
         double prob = profileData.getDesignatedSuccessorProbability();
-        assert prob >= 0 - ProfileData.EPSILON && prob <= 1 + ProfileData.EPSILON : "Probability out of bounds: " + prob;
-        double trueSuccessorProbability = Math.clamp(prob, 0.0, 1.0);
+        assert ProfileData.isApproximatelyInRange(prob, 0.0, 1.0) : "Probability out of bounds: " + prob;
+        double trueSuccessorProbability = Math.min(1.0, Math.max(0.0, prob));
         this.profileData = profileData.copy(trueSuccessorProbability);
     }
 

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/IfNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/IfNode.java
@@ -175,8 +175,8 @@ public final class IfNode extends ControlSplitNode implements Simplifiable, LIRL
 
     public void setTrueSuccessorProbability(BranchProbabilityData profileData) {
         double prob = profileData.getDesignatedSuccessorProbability();
-        assert prob >= -0.000000001 && prob <= 1.000000001 : "Probability out of bounds: " + prob;
-        double trueSuccessorProbability = Math.min(1.0, Math.max(0.0, prob));
+        assert prob >= 0 - ProfileData.EPSILON && prob <= 1 + ProfileData.EPSILON : "Probability out of bounds: " + prob;
+        double trueSuccessorProbability = Math.clamp(prob, 0.0, 1.0);
         this.profileData = profileData.copy(trueSuccessorProbability);
     }
 

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/ProfileData.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/ProfileData.java
@@ -38,6 +38,12 @@ import jdk.vm.ci.meta.ProfilingInfo;
  */
 public abstract class ProfileData {
 
+    /**
+     * The smallest possible difference between two numerical probabilities/frequencies. Should be
+     * used as a threshold for floating-point comparisons.
+     */
+    public static final double EPSILON = 1e-9;
+
     protected final ProfileSource profileSource;
 
     protected ProfileData(ProfileSource profileSource) {

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/ProfileData.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/ProfileData.java
@@ -37,13 +37,6 @@ import jdk.vm.ci.meta.ProfilingInfo;
  * {@link LoopFrequencyData}, {@link SwitchProbabilityData}
  */
 public abstract class ProfileData {
-
-    /**
-     * The smallest possible difference between two numerical probabilities/frequencies. Should be
-     * used as a threshold for floating-point comparisons.
-     */
-    public static final double EPSILON = 1e-9;
-
     protected final ProfileSource profileSource;
 
     protected ProfileData(ProfileSource profileSource) {
@@ -127,6 +120,32 @@ public abstract class ProfileData {
 
     public ProfileSource getProfileSource() {
         return profileSource;
+    }
+
+    /**
+     * The smallest possible difference between two numerical probabilities/frequencies. Should be
+     * used as a threshold for floating-point comparisons.
+     */
+    public static final double EPSILON = 1e-9;
+
+    /**
+     * Compares two probabilities for approximate equality with a threshold of {@link #EPSILON}.
+     *
+     * @return {@code true} iff the absolute difference between the two probabilities is smaller or
+     *         equal to {@link #EPSILON}.
+     */
+    public static boolean isApproximatelyEqual(double probability, double expected) {
+        return Math.abs(probability - expected) <= EPSILON;
+    }
+
+    /**
+     * Determines whether a probability lies in a given allowed range, allowing for a threshold of
+     * {@link #EPSILON}.
+     *
+     * @return {@code true} iff {@code (min - EPSILON) <= probability <= (max + EPSILON)}.
+     */
+    public static boolean isApproximatelyInRange(double probability, double min, double max) {
+        return min - EPSILON <= probability && probability <= max + EPSILON;
     }
 
     /**

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/extended/SwitchNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/extended/SwitchNode.java
@@ -106,7 +106,7 @@ public abstract class SwitchNode extends ControlSplitNode {
             total += d;
             GraalError.guarantee(d >= 0.0, "Cannot have negative probabilities in switch node: %s", d);
         }
-        GraalError.guarantee(total > 0.999 && total < 1.001, "Total probability across branches not equal to one: %.4f", total);
+        GraalError.guarantee(Math.abs(total - 1.0) <= ProfileData.EPSILON, "Total probability across branches not equal to one: %.10f", total);
         return true;
     }
 
@@ -130,7 +130,6 @@ public abstract class SwitchNode extends ControlSplitNode {
     public boolean setProbability(AbstractBeginNode successor, BranchProbabilityData successorProfileData) {
         double newProbability = successorProfileData.getDesignatedSuccessorProbability();
         assert newProbability <= 1.0 && newProbability >= 0.0 : newProbability;
-        assert assertProbabilities();
 
         double[] keyProbabilities = getKeyProbabilities().clone();
         double sum = 0;

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/extended/SwitchNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/extended/SwitchNode.java
@@ -106,7 +106,8 @@ public abstract class SwitchNode extends ControlSplitNode {
             total += d;
             GraalError.guarantee(d >= 0.0, "Cannot have negative probabilities in switch node: %s", d);
         }
-        GraalError.guarantee(Math.abs(total - 1.0) <= ProfileData.EPSILON, "Total probability across branches not equal to one: %.10f", total);
+        GraalError.guarantee(ProfileData.isApproximatelyEqual(total, 1.0),
+                        "Total probability across branches not equal to one: %.10f", total);
         return true;
     }
 

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/loop/DefaultLoopPolicies.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/loop/DefaultLoopPolicies.java
@@ -45,6 +45,7 @@ import static org.graalvm.compiler.nodes.loop.DefaultLoopPolicies.Options.Unroll
 import java.util.List;
 
 import org.graalvm.collections.EconomicMap;
+<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/loop/DefaultLoopPolicies.java
 import org.graalvm.compiler.core.common.cfg.BasicBlock;
 import org.graalvm.compiler.core.common.cfg.Loop;
 import org.graalvm.compiler.core.common.util.UnsignedLong;
@@ -69,6 +70,33 @@ import org.graalvm.compiler.options.Option;
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.options.OptionType;
 import org.graalvm.compiler.options.OptionValues;
+=======
+
+import jdk.graal.compiler.core.common.cfg.BasicBlock;
+import jdk.graal.compiler.core.common.cfg.Loop;
+import jdk.graal.compiler.core.common.util.UnsignedLong;
+import jdk.graal.compiler.debug.DebugContext;
+import jdk.graal.compiler.debug.GraalError;
+import jdk.graal.compiler.graph.Node;
+import jdk.graal.compiler.graph.NodeBitMap;
+import jdk.graal.compiler.nodes.AbstractBeginNode;
+import jdk.graal.compiler.nodes.ControlSplitNode;
+import jdk.graal.compiler.nodes.Invoke;
+import jdk.graal.compiler.nodes.LoopBeginNode;
+import jdk.graal.compiler.nodes.ProfileData;
+import jdk.graal.compiler.nodes.StructuredGraph;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.calc.CompareNode;
+import jdk.graal.compiler.nodes.cfg.ControlFlowGraph;
+import jdk.graal.compiler.nodes.cfg.HIRBlock;
+import jdk.graal.compiler.nodes.debug.ControlFlowAnchorNode;
+import jdk.graal.compiler.nodes.extended.ForeignCall;
+import jdk.graal.compiler.nodes.spi.CoreProviders;
+import jdk.graal.compiler.options.Option;
+import jdk.graal.compiler.options.OptionKey;
+import jdk.graal.compiler.options.OptionType;
+import jdk.graal.compiler.options.OptionValues;
+>>>>>>> c5586894366 (Add epsilon to more floating-point probability comparisons):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/loop/DefaultLoopPolicies.java
 
 public class DefaultLoopPolicies implements LoopPolicies {
 
@@ -578,14 +606,14 @@ public class DefaultLoopPolicies implements LoopPolicies {
                         factor *= p;
                     }
                 }
-                assert 0 <= factor && factor <= 1 : "factor should be between 0 and 1, but is : " + factor;
+                assert 0 <= factor && factor <= 1 + ProfileData.EPSILON : "factor should be between 0 and 1, but is : " + factor;
             } else {
                 debug.log("control split %s has an untrusted profile source", split);
                 factor = DefaultUnswitchFactor.getValue(options);
             }
 
             // We cap the factor and we invert it to make guards' range narrow.
-            double cappedFactor = 1 - Math.min(Math.max(factor, LoopUnswitchFrequencyMinFactor.getValue(options)), LoopUnswitchFrequencyMaxFactor.getValue(options));
+            double cappedFactor = 1 - Math.clamp(factor, LoopUnswitchFrequencyMinFactor.getValue(options), LoopUnswitchFrequencyMaxFactor.getValue(options));
 
             if (splitFrequency < cappedFactor * localLoopFrequency) {
                 /*

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/loop/DefaultLoopPolicies.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/loop/DefaultLoopPolicies.java
@@ -45,7 +45,7 @@ import static org.graalvm.compiler.nodes.loop.DefaultLoopPolicies.Options.Unroll
 import java.util.List;
 
 import org.graalvm.collections.EconomicMap;
-<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/loop/DefaultLoopPolicies.java
+
 import org.graalvm.compiler.core.common.cfg.BasicBlock;
 import org.graalvm.compiler.core.common.cfg.Loop;
 import org.graalvm.compiler.core.common.util.UnsignedLong;
@@ -57,7 +57,7 @@ import org.graalvm.compiler.nodes.AbstractBeginNode;
 import org.graalvm.compiler.nodes.ControlSplitNode;
 import org.graalvm.compiler.nodes.Invoke;
 import org.graalvm.compiler.nodes.LoopBeginNode;
-import org.graalvm.compiler.nodes.ProfileData.ProfileSource;
+import org.graalvm.compiler.nodes.ProfileData;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.CompareNode;
@@ -70,33 +70,6 @@ import org.graalvm.compiler.options.Option;
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.options.OptionType;
 import org.graalvm.compiler.options.OptionValues;
-=======
-
-import jdk.graal.compiler.core.common.cfg.BasicBlock;
-import jdk.graal.compiler.core.common.cfg.Loop;
-import jdk.graal.compiler.core.common.util.UnsignedLong;
-import jdk.graal.compiler.debug.DebugContext;
-import jdk.graal.compiler.debug.GraalError;
-import jdk.graal.compiler.graph.Node;
-import jdk.graal.compiler.graph.NodeBitMap;
-import jdk.graal.compiler.nodes.AbstractBeginNode;
-import jdk.graal.compiler.nodes.ControlSplitNode;
-import jdk.graal.compiler.nodes.Invoke;
-import jdk.graal.compiler.nodes.LoopBeginNode;
-import jdk.graal.compiler.nodes.ProfileData;
-import jdk.graal.compiler.nodes.StructuredGraph;
-import jdk.graal.compiler.nodes.ValueNode;
-import jdk.graal.compiler.nodes.calc.CompareNode;
-import jdk.graal.compiler.nodes.cfg.ControlFlowGraph;
-import jdk.graal.compiler.nodes.cfg.HIRBlock;
-import jdk.graal.compiler.nodes.debug.ControlFlowAnchorNode;
-import jdk.graal.compiler.nodes.extended.ForeignCall;
-import jdk.graal.compiler.nodes.spi.CoreProviders;
-import jdk.graal.compiler.options.Option;
-import jdk.graal.compiler.options.OptionKey;
-import jdk.graal.compiler.options.OptionType;
-import jdk.graal.compiler.options.OptionValues;
->>>>>>> c5586894366 (Add epsilon to more floating-point probability comparisons):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/loop/DefaultLoopPolicies.java
 
 public class DefaultLoopPolicies implements LoopPolicies {
 
@@ -422,7 +395,7 @@ public class DefaultLoopPolicies implements LoopPolicies {
         StructuredGraph graph = loop.loopBegin().graph();
         OptionValues options = loop.loopBegin().getOptions();
 
-        boolean isTrusted = ProfileSource.isTrusted(loop.localFrequencySource());
+        boolean isTrusted = ProfileData.ProfileSource.isTrusted(loop.localFrequencySource());
         double loopFrequency = isTrusted ? loop.localLoopFrequency() : DefaultLoopFrequency.getValue(options);
         /* When a loop has a greater local loop frequency we allow a bigger change in code size */
         int maxDiff = LoopUnswitchTrivial.getValue(options) + (int) (LoopUnswitchFrequencyBoost.getValue(options) * (loopFrequency - 1.0));
@@ -456,7 +429,7 @@ public class DefaultLoopPolicies implements LoopPolicies {
         for (List<ControlSplitNode> split : controlSplits.getValues()) {
             boolean isTrusted = true;
             for (ControlSplitNode node : split) {
-                isTrusted = isTrusted && ProfileSource.isTrusted(node.getProfileData().getProfileSource());
+                isTrusted = isTrusted && ProfileData.ProfileSource.isTrusted(node.getProfileData().getProfileSource());
             }
 
             int approxCodeSizeChange = approxCodeSizeChange(loop, split);
@@ -606,14 +579,14 @@ public class DefaultLoopPolicies implements LoopPolicies {
                         factor *= p;
                     }
                 }
-                assert 0 <= factor && factor <= 1 + ProfileData.EPSILON : "factor should be between 0 and 1, but is : " + factor;
+                assert ProfileData.isApproximatelyInRange(factor, 0.0, 1.0) : "factor should be between 0 and 1, but is : " + factor;
             } else {
                 debug.log("control split %s has an untrusted profile source", split);
                 factor = DefaultUnswitchFactor.getValue(options);
             }
 
             // We cap the factor and we invert it to make guards' range narrow.
-            double cappedFactor = 1 - Math.clamp(factor, LoopUnswitchFrequencyMinFactor.getValue(options), LoopUnswitchFrequencyMaxFactor.getValue(options));
+            double cappedFactor = 1 - Math.min(Math.max(factor, LoopUnswitchFrequencyMinFactor.getValue(options)), LoopUnswitchFrequencyMaxFactor.getValue(options));
 
             if (splitFrequency < cappedFactor * localLoopFrequency) {
                 /*

--- a/espresso/ci/ci_common/common.jsonnet
+++ b/espresso/ci/ci_common/common.jsonnet
@@ -41,8 +41,8 @@ local benchmark_suites = ['dacapo', 'renaissance', 'scala-dacapo'];
     },
   },
 
-  x52: {
-    capabilities+: ['no_frequency_scaling', 'tmpfs25g', 'x52'],
+  e3: {
+    capabilities+: ['no_frequency_scaling', 'tmpfs25g', 'e3'],
   },
 
   darwin_amd64: self.common + graal_common.darwin_amd64 + {
@@ -85,7 +85,7 @@ local benchmark_suites = ['dacapo', 'renaissance', 'scala-dacapo'];
   jdk21_gate_darwin_amd64       : self.gate          + self.darwin_amd64_21,
   jdk21_gate_darwin_aarch64     : self.gate          + self.darwin_aarch64_21,
   jdk21_gate_windows_amd64      : self.gate          + self.windows_21,
-  jdk21_bench_linux             : self.bench         + self.linux_amd64_21 + self.x52,
+  jdk21_bench_linux             : self.bench         + self.linux_amd64_21 + self.e3,
   jdk21_bench_darwin            : self.bench         + self.darwin_amd64_21,
   jdk21_bench_windows           : self.bench         + self.windows_21,
   jdk21_daily_linux_amd64       : self.daily         + self.linux_amd64_21,
@@ -93,7 +93,7 @@ local benchmark_suites = ['dacapo', 'renaissance', 'scala-dacapo'];
   jdk21_daily_darwin_amd64      : self.daily         + self.darwin_amd64_21,
   jdk21_daily_darwin_aarch64    : self.daily         + self.darwin_aarch64_21,
   jdk21_daily_windows_amd64     : self.daily         + self.windows_21,
-  jdk21_daily_bench_linux       : self.dailyBench    + self.linux_amd64_21 + self.x52,
+  jdk21_daily_bench_linux       : self.dailyBench    + self.linux_amd64_21 + self.e3,
   jdk21_daily_bench_darwin      : self.dailyBench    + self.darwin_amd64_21,
   jdk21_daily_bench_windows     : self.dailyBench    + self.windows_21,
   jdk21_weekly_linux_amd64      : self.weekly        + self.linux_amd64_21,
@@ -106,13 +106,13 @@ local benchmark_suites = ['dacapo', 'renaissance', 'scala-dacapo'];
   jdk21_monthly_darwin_amd64    : self.monthly        + self.darwin_amd64_21,
   jdk21_monthly_darwin_aarch64  : self.monthly        + self.darwin_aarch64_21,
   jdk21_monthly_windows_amd64   : self.monthly        + self.windows_21,
-  jdk21_weekly_bench_linux      : self.weeklyBench   + self.linux_amd64_21 + self.x52,
+  jdk21_weekly_bench_linux      : self.weeklyBench   + self.linux_amd64_21 + self.e3,
   jdk21_weekly_bench_darwin     : self.weeklyBench   + self.darwin_amd64_21,
   jdk21_weekly_bench_windows    : self.weeklyBench   + self.windows_21,
   jdk21_on_demand_linux         : self.onDemand      + self.linux_amd64_21,
   jdk21_on_demand_darwin        : self.onDemand      + self.darwin_amd64_21,
   jdk21_on_demand_windows       : self.onDemand      + self.windows_21,
-  jdk21_on_demand_bench_linux   : self.onDemandBench + self.linux_amd64_21 + self.x52,
+  jdk21_on_demand_bench_linux   : self.onDemandBench + self.linux_amd64_21 + self.e3,
   jdk21_on_demand_bench_darwin  : self.onDemandBench + self.darwin_amd64_21,
   jdk21_on_demand_bench_windows : self.onDemandBench + self.windows_21,
 

--- a/graal-common.json
+++ b/graal-common.json
@@ -1,6 +1,6 @@
 {
   "README": "This file contains definitions that are useful for the jsonnet CI files of the graal and graal-enterprise repositories.",
   "ci": {
-    "overlay": "f85c63d782782fc566bd661a1d638f8f9bb65b2e"
+    "overlay": "3931cb00c4246f0f1be2a4335f1689ee72445fac"
   }
 }

--- a/graal-common.json
+++ b/graal-common.json
@@ -1,6 +1,6 @@
 {
   "README": "This file contains definitions that are useful for the jsonnet CI files of the graal and graal-enterprise repositories.",
   "ci": {
-    "overlay": "5d3f7c022b75d0acf5e784392ff64497fd3cf1dd"
+    "overlay": "d2710da96199f53061cef01351e5261da68d597b"
   }
 }

--- a/graal-common.json
+++ b/graal-common.json
@@ -1,6 +1,6 @@
 {
   "README": "This file contains definitions that are useful for the jsonnet CI files of the graal and graal-enterprise repositories.",
   "ci": {
-    "overlay": "3931cb00c4246f0f1be2a4335f1689ee72445fac"
+    "overlay": "5d3f7c022b75d0acf5e784392ff64497fd3cf1dd"
   }
 }

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/c/type/CCharPointer.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/c/type/CCharPointer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -49,7 +49,7 @@ import org.graalvm.word.SignedWord;
  *
  * @since 19.0
  */
-@CPointerTo(nameOfCType = "char")
+@CPointerTo(nameOfCType = "signed char")
 public interface CCharPointer extends PointerBase {
 
     /**

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
@@ -110,7 +110,8 @@ public final class SerialGCOptions {
     @Option(help = "Develop demographics of the object references visited. Serial GC only.", type = OptionType.Debug)//
     public static final HostedOptionKey<Boolean> GreyToBlackObjRefDemographics = new HostedOptionKey<>(false, SerialGCOptions::serialGCOnly);
 
-    @Option(help = "Ignore the maximum heap size while a VM operation is executed.", type = OptionType.Expert)//
+    /* Option should be renamed, see GR-53798. */
+    @Option(help = "Ignore the maximum heap size while in VM-internal code.", type = OptionType.Expert)//
     public static final HostedOptionKey<Boolean> IgnoreMaxHeapSizeWhileInVMOperation = new HostedOptionKey<>(false, SerialGCOptions::serialGCOnly);
 
     private SerialGCOptions() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -739,8 +739,12 @@ public class SubstrateOptions {
     public static final HostedOptionKey<Integer> GenerateDebugInfo = new HostedOptionKey<>(0, SubstrateOptions::validateGenerateDebugInfo) {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Integer oldValue, Integer newValue) {
-            if (OS.WINDOWS.isCurrent()) {
-                /* Keep symbols on Windows. The symbol table is part of the pdb-file. */
+            if (!OS.DARWIN.isCurrent()) {
+                /*
+                 * Keep the symbol table, as it may be used by debugging or profiling tools (e.g.,
+                 * perf). On Windows, the symbol table is included in the pdb-file, while on Linux,
+                 * it is part of the .debug file.
+                 */
                 DeleteLocalSymbols.update(values, newValue == 0);
             }
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/StackOverflowCheckImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/StackOverflowCheckImpl.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.graal.snippets;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
 import static org.graalvm.compiler.nodes.extended.BranchProbabilityNode.EXTREMELY_SLOW_PATH_PROBABILITY;
 import static org.graalvm.compiler.nodes.extended.BranchProbabilityNode.probability;
 
@@ -208,6 +209,7 @@ public final class StackOverflowCheckImpl implements StackOverflowCheck {
     }
 
     @Override
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public boolean isYellowZoneAvailable() {
         return yellowZoneStateTL.get() > STATE_YELLOW_ENABLED;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceHandler.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceHandler.java
@@ -27,6 +27,7 @@ package com.oracle.svm.core.heap;
 import java.lang.ref.Reference;
 
 import com.oracle.svm.core.IsolateArgumentParser;
+import com.oracle.svm.core.NeverInline;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.stack.StackOverflowCheck;
@@ -62,6 +63,7 @@ public final class ReferenceHandler {
         }
     }
 
+    @NeverInline("Ensure that every exception can be caught, including implicit exceptions.")
     static void processCleaners() {
         // Note: (sun.misc|jdk.internal).Cleaner objects are invoked in pending reference processing
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceHandlerThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceHandlerThread.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.svm.core.heap;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.nativeimage.CurrentIsolate;
 import org.graalvm.nativeimage.ImageSingletons;
@@ -32,6 +34,7 @@ import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.SubstrateOptions;
+import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.thread.ThreadingSupportImpl;
@@ -55,6 +58,7 @@ public final class ReferenceHandlerThread implements Runnable {
         }
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static boolean isReferenceHandlerThread() {
         if (isSupported()) {
             return CurrentIsolate.getCurrentThread() == singleton().isolateThread;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceHandlerThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceHandlerThread.java
@@ -83,7 +83,11 @@ public final class ReferenceHandlerThread implements Runnable {
         } catch (InterruptedException e) {
             VMError.guarantee(VMThreads.isTearingDown(), "Reference Handler should only be interrupted during tear-down");
         } catch (Throwable t) {
-            VMError.shouldNotReachHere("Reference processing and cleaners must handle all potential exceptions", t);
+            if (t instanceof OutOfMemoryError && VMThreads.isTearingDown()) {
+                // Likely failed to allocate the InterruptedException, ignore either way.
+            } else {
+                VMError.shouldNotReachHere("Reference processing and cleaners must handle all potential exceptions", t);
+            }
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
@@ -42,7 +42,6 @@ import com.oracle.svm.core.NeverInline;
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.thread.VMOperation;
-import com.oracle.svm.core.util.BasedOnJDKClass;
 import com.oracle.svm.core.util.TimeUtils;
 
 import jdk.vm.ci.meta.MetaAccessProvider;
@@ -54,7 +53,6 @@ import jdk.vm.ci.meta.ResolvedJavaType;
  * not injected into {@link Target_java_lang_ref_Reference} so that subclasses of {@link Reference}
  * cannot interfere with them.
  */
-@BasedOnJDKClass(Reference.class)
 public final class ReferenceInternals {
     public static final String REFERENT_FIELD_NAME = "referent";
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
@@ -38,11 +38,12 @@ import org.graalvm.compiler.word.Word;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.WordFactory;
 
+import com.oracle.svm.core.NeverInline;
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.thread.VMOperation;
+import com.oracle.svm.core.util.BasedOnJDKClass;
 import com.oracle.svm.core.util.TimeUtils;
-import com.oracle.svm.core.util.VMError;
 
 import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.ResolvedJavaField;
@@ -53,6 +54,7 @@ import jdk.vm.ci.meta.ResolvedJavaType;
  * not injected into {@link Target_java_lang_ref_Reference} so that subclasses of {@link Reference}
  * cannot interfere with them.
  */
+@BasedOnJDKClass(Reference.class)
 public final class ReferenceInternals {
     public static final String REFERENT_FIELD_NAME = "referent";
 
@@ -159,12 +161,20 @@ public final class ReferenceInternals {
     private static final Object processPendingLock = new Object();
     private static boolean processPendingActive = false;
 
+    @NeverInline("Ensure that every exception can be caught, including implicit exceptions.")
     public static void waitForPendingReferences() throws InterruptedException {
         Heap.getHeap().waitForReferencePendingList();
     }
 
+    @NeverInline("Ensure that every exception can be caught, including implicit exceptions.")
     @SuppressFBWarnings(value = "NN_NAKED_NOTIFY", justification = "Notifies on progress, not a specific state change.")
     public static void processPendingReferences() {
+        /*
+         * Note that catching an OutOfMemoryError (e.g. from failing to allocate another exception)
+         * from here and resuming is not advisable because it can break synchronization. We should
+         * generally see these only when processing individual references or cleaners.
+         */
+
         Target_java_lang_ref_Reference<?> pendingList;
         synchronized (processPendingLock) {
             if (processPendingActive) {
@@ -184,32 +194,28 @@ public final class ReferenceInternals {
 
         // Process all references that were discovered by the GC.
         do {
-            try {
-                while (pendingList != null) {
-                    Target_java_lang_ref_Reference<?> ref = pendingList;
-                    pendingList = ref.discovered;
-                    ref.discovered = null;
+            while (pendingList != null) {
+                Target_java_lang_ref_Reference<?> ref = pendingList;
+                pendingList = ref.discovered;
+                ref.discovered = null;
 
-                    if (Target_jdk_internal_ref_Cleaner.class.isInstance(ref)) {
-                        Target_jdk_internal_ref_Cleaner cleaner = Target_jdk_internal_ref_Cleaner.class.cast(ref);
-                        // Cleaner catches all exceptions, cannot be overridden due to private c'tor
-                        cleaner.clean();
-                        synchronized (processPendingLock) {
-                            // Notify any waiters that progress has been made. This improves latency
-                            // for nio.Bits waiters, which are the only important ones.
-                            processPendingLock.notifyAll();
-                        }
-                    } else {
-                        @SuppressWarnings("unchecked")
-                        Target_java_lang_ref_ReferenceQueue<? super Object> queue = SubstrateUtil.cast(ref.queue, Target_java_lang_ref_ReferenceQueue.class);
-                        if (queue != Target_java_lang_ref_ReferenceQueue.NULL) {
-                            // Enqueues, avoiding the potentially overridden Reference.enqueue().
-                            queue.enqueue(ref);
-                        }
+                if (Target_jdk_internal_ref_Cleaner.class.isInstance(ref)) {
+                    Target_jdk_internal_ref_Cleaner cleaner = Target_jdk_internal_ref_Cleaner.class.cast(ref);
+                    // Cleaner catches all exceptions, cannot be overridden due to private c'tor
+                    cleaner.clean();
+                    synchronized (processPendingLock) {
+                        // Notify any waiters that progress has been made. This improves latency
+                        // for nio.Bits waiters, which are the only important ones.
+                        processPendingLock.notifyAll();
+                    }
+                } else {
+                    @SuppressWarnings("unchecked")
+                    Target_java_lang_ref_ReferenceQueue<? super Object> queue = SubstrateUtil.cast(ref.queue, Target_java_lang_ref_ReferenceQueue.class);
+                    if (queue != Target_java_lang_ref_ReferenceQueue.NULL) {
+                        // Enqueues, avoiding the potentially overridden Reference.enqueue().
+                        queue.enqueue(ref);
                     }
                 }
-            } catch (Throwable t) {
-                VMError.shouldNotReachHere("ReferenceQueue and Cleaner must handle all potential exceptions", t);
             }
 
             synchronized (processPendingLock) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Target_jdk_internal_ref_Cleaner.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Target_jdk_internal_ref_Cleaner.java
@@ -29,7 +29,9 @@ import java.lang.ref.ReferenceQueue;
 
 import org.graalvm.nativeimage.hosted.FieldValueTransformer;
 
+import com.oracle.svm.core.NeverInline;
 import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.AnnotateOriginal;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
@@ -64,7 +66,8 @@ final class Target_java_lang_ref_Cleaner {
 
 @TargetClass(className = "java.lang.ref.Cleaner$Cleanable")
 final class Target_java_lang_ref_Cleaner_Cleanable {
-    @Alias
+    @AnnotateOriginal
+    @NeverInline("Ensure that every exception can be caught, including implicit exceptions.")
     native void clean();
 }
 
@@ -119,6 +122,10 @@ final class Target_jdk_internal_ref_PhantomCleanable {
 
     @Alias
     native boolean isListEmpty();
+
+    @AnnotateOriginal
+    @NeverInline("Ensure that every exception can be caught, including implicit exceptions.")
+    /* final */ native void clean();
 }
 
 final class HolderObjectFieldTransformer implements FieldValueTransformer {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoStripFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoStripFeature.java
@@ -28,10 +28,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.graalvm.compiler.core.common.SuppressFBWarnings;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.debug.DebugContext.Builder;
 import org.graalvm.compiler.debug.Indent;
 import org.graalvm.compiler.printer.GraalDebugHandlersFactory;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.impl.InternalPlatform;
 
 import com.oracle.graal.pointsto.util.GraalAccess;
 import com.oracle.objectfile.ObjectFile;
@@ -52,7 +55,7 @@ public class NativeImageDebugInfoStripFeature implements InternalFeature {
 
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
-        return SubstrateOptions.useDebugInfoGeneration() && SubstrateOptions.StripDebugInfo.getValue();
+        return SubstrateOptions.StripDebugInfo.getValue();
     }
 
     @SuppressWarnings("try")
@@ -77,13 +80,17 @@ public class NativeImageDebugInfoStripFeature implements InternalFeature {
         }
     }
 
+    @SuppressFBWarnings(value = "", justification = "FB reports null pointer dereferencing although it is not possible in this case.")
     private static void stripLinux(AfterImageWriteAccessImpl accessImpl) {
         String objcopyExe = "objcopy";
         String debugExtension = ".debug";
         Path imagePath = accessImpl.getImagePath();
+        if (imagePath == null) {
+            assert !Platform.includedIn(InternalPlatform.NATIVE_ONLY.class);
+            return;
+        }
+
         Path imageName = imagePath.getFileName();
-        Path outputDirectory = imagePath.getParent();
-        String debugInfoName = imageName + debugExtension;
         boolean objcopyAvailable = false;
         try {
             objcopyAvailable = FileUtils.executeCommand(objcopyExe, "--version") == 0;
@@ -94,16 +101,21 @@ public class NativeImageDebugInfoStripFeature implements InternalFeature {
         }
 
         if (!objcopyAvailable) {
-            LogUtils.warning("%s not available. Skipping generation of separate debuginfo file %s, debuginfo will remain embedded in the executable.", objcopyExe, debugInfoName);
+            LogUtils.warning("%s not available. The debuginfo will remain embedded in the executable.", objcopyExe);
         } else {
             try {
+                Path outputDirectory = imagePath.getParent();
                 String imageFilePath = outputDirectory.resolve(imageName).toString();
-                Path debugInfoFilePath = outputDirectory.resolve(debugInfoName);
-                FileUtils.executeCommand(objcopyExe, "--only-keep-debug", imageFilePath, debugInfoFilePath.toString());
-                BuildArtifacts.singleton().add(ArtifactType.DEBUG_INFO, debugInfoFilePath);
+                if (SubstrateOptions.useDebugInfoGeneration()) {
+                    /* Generate a separate debug file before stripping the executable. */
+                    String debugInfoName = imageName + debugExtension;
+                    Path debugInfoFilePath = outputDirectory.resolve(debugInfoName);
+                    FileUtils.executeCommand(objcopyExe, "--only-keep-debug", imageFilePath, debugInfoFilePath.toString());
+                    BuildArtifacts.singleton().add(ArtifactType.DEBUG_INFO, debugInfoFilePath);
+                    FileUtils.executeCommand(objcopyExe, "--add-gnu-debuglink=" + debugInfoFilePath, imageFilePath);
+                }
                 Path exportedSymbolsPath = createKeepSymbolsListFile(accessImpl);
                 FileUtils.executeCommand(objcopyExe, "--strip-all", "--keep-symbols=" + exportedSymbolsPath, imageFilePath);
-                FileUtils.executeCommand(objcopyExe, "--add-gnu-debuglink=" + debugInfoFilePath, imageFilePath);
             } catch (IOException e) {
                 throw UserError.abort("Generation of separate debuginfo file failed", e);
             } catch (InterruptedException e) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoStripFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoStripFeature.java
@@ -114,7 +114,7 @@ public class NativeImageDebugInfoStripFeature implements InternalFeature {
 
     private static Path createKeepSymbolsListFile(AfterImageWriteAccessImpl accessImpl) throws IOException {
         Path exportedSymbolsPath = accessImpl.getTempDirectory().resolve("keep-symbols.list").toAbsolutePath();
-        Files.write(exportedSymbolsPath, accessImpl.getImageSymbols(false));
+        Files.write(exportedSymbolsPath, accessImpl.getImageSymbols(true));
         return exportedSymbolsPath;
     }
 }

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog summarizes major changes between Truffle Tools versions.
 
+## Version 23.1.4
+* GR-53413: `CPUSampler` no longer guarantees to keep all contexts on the engine alive. As a result `CPUSampler#getData()` is deprecated and may not return data for all contexts on the engine. The contexts that were already collected by GC won't be in the returned map. `CPUSamplerData#getContext()` is also deprecated and returns null if the context was already collected.
+* GR-53413: `CPUSamplerData#getDataList()` was introduced and returns all data collected by the sampler as a list of `CPUSamplerData`. For each context on the engine, including the ones that were already collected, there is a corresponding element in the list. `CPUSamplerData#getContextIndex()` returns the index of the data in the list.
+
 ## Version 23.0.0
 * GR-41407: Added new option `--dap.SourcePath` to allow to resolve sources with relative paths.
 

--- a/tools/src/com.oracle.truffle.tools.chromeinspector/src/com/oracle/truffle/tools/chromeinspector/InspectorProfiler.java
+++ b/tools/src/com.oracle.truffle.tools.chromeinspector/src/com/oracle/truffle/tools/chromeinspector/InspectorProfiler.java
@@ -35,8 +35,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.graalvm.shadowed.org.json.JSONArray;
+import org.graalvm.shadowed.org.json.JSONObject;
+
 import com.oracle.truffle.api.InstrumentInfo;
-import com.oracle.truffle.api.TruffleContext;
 import com.oracle.truffle.api.instrumentation.SourceSectionFilter;
 import com.oracle.truffle.api.instrumentation.StandardTags;
 import com.oracle.truffle.api.source.Source;
@@ -62,8 +64,6 @@ import com.oracle.truffle.tools.profiler.CPUTracer;
 import com.oracle.truffle.tools.profiler.ProfilerNode;
 import com.oracle.truffle.tools.profiler.impl.CPUSamplerInstrument;
 import com.oracle.truffle.tools.profiler.impl.CPUTracerInstrument;
-import org.graalvm.shadowed.org.json.JSONArray;
-import org.graalvm.shadowed.org.json.JSONObject;
 
 public final class InspectorProfiler extends ProfilerDomain {
 
@@ -127,12 +127,12 @@ public final class InspectorProfiler extends ProfilerDomain {
     @Override
     public Params stop() {
         long time = System.currentTimeMillis();
-        Map<TruffleContext, CPUSamplerData> data;
+        List<CPUSamplerData> data;
         long period;
         synchronized (sampler) {
             sampler.setCollecting(false);
             sampler.setGatherSelfHitTimes(oldGatherSelfHitTimes);
-            data = sampler.getData();
+            data = sampler.getDataList();
             sampler.clearData();
             period = sampler.getPeriod();
         }
@@ -141,9 +141,9 @@ public final class InspectorProfiler extends ProfilerDomain {
         return profile;
     }
 
-    private static Collection<ProfilerNode<CPUSampler.Payload>> getRootNodes(Map<TruffleContext, CPUSamplerData> data) {
+    private static Collection<ProfilerNode<CPUSampler.Payload>> getRootNodes(List<CPUSamplerData> data) {
         Collection<ProfilerNode<CPUSampler.Payload>> retVal = new ArrayList<>();
-        for (CPUSamplerData samplerData : data.values()) {
+        for (CPUSamplerData samplerData : data) {
             for (Collection<ProfilerNode<CPUSampler.Payload>> profilerNodes : samplerData.getThreadData().values()) {
                 retVal.addAll(profilerNodes);
             }
@@ -151,8 +151,8 @@ public final class InspectorProfiler extends ProfilerDomain {
         return retVal;
     }
 
-    private static long getSampleCount(Map<TruffleContext, CPUSamplerData> data) {
-        return data.values().stream().map(CPUSamplerData::getSamples).reduce(0L, Long::sum);
+    private static long getSampleCount(List<CPUSamplerData> data) {
+        return data.stream().map(CPUSamplerData::getSamples).reduce(0L, Long::sum);
     }
 
     @Override

--- a/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/CPUSamplerMultiContextTest.java
+++ b/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/CPUSamplerMultiContextTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.tools.profiler.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyExecutable;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.oracle.truffle.api.test.GCUtils;
+import com.oracle.truffle.tools.profiler.CPUSampler;
+import com.oracle.truffle.tools.profiler.StackTraceEntry;
+
+public class CPUSamplerMultiContextTest {
+    public static final String FIB = """
+                    function fib(n) {
+                      if (n < 3) {
+                        return 1;
+                      } else {
+                        return fib(n - 1) + fib(n - 2);
+                      }
+                    }
+                    function main() {
+                      return fib;
+                    }
+                    """;
+
+    public static final String FIB_15_PLUS = """
+                    function fib15plus(n, remainder) {
+                      if (n < 15) {
+                        return remainder(n);
+                      } else {
+                        return fib15plus(n - 1, remainder) + fib15plus(n - 2, remainder);
+                      }
+                    }
+                    function main() {
+                      return fib15plus;
+                    }
+                    """;
+
+    @Test
+    public void testSamplerDoesNotKeepContexts() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (Engine engine = Engine.newBuilder().out(out).option("cpusampler", "histogram").build()) {
+            List<WeakReference<Context>> contextReferences = new ArrayList<>();
+            for (int i = 0; i < 27; i++) {
+                try (Context context = Context.newBuilder().engine(engine).build()) {
+                    contextReferences.add(new WeakReference<>(context));
+                    Source src = Source.newBuilder("sl", FIB, "fib.sl").build();
+                    Value fib = context.eval(src);
+                    fib.execute(29);
+                }
+            }
+            GCUtils.assertGc("CPUSampler prevented collecting contexts", contextReferences);
+        }
+        Pattern pattern = Pattern.compile("Sampling Histogram. Recorded (\\d+) samples");
+        Matcher matcher = pattern.matcher(out.toString());
+        int histogramCount = 0;
+        while (matcher.find()) {
+            histogramCount++;
+            Assert.assertTrue("Histogram no. " + histogramCount + " didn't contain any samples.", Integer.parseInt(matcher.group(1)) > 0);
+        }
+        Assert.assertEquals(27, histogramCount);
+    }
+
+    static class RootCounter {
+        int fibCount;
+        int fib15plusCount;
+    }
+
+    @Test
+    public void testMultiThreadedAndMultiContextPerThread() throws InterruptedException, ExecutionException, IOException {
+        try (Engine engine = Engine.create(); ExecutorService executorService = Executors.newFixedThreadPool(10)) {
+            AtomicBoolean runFlag = new AtomicBoolean(true);
+            CPUSampler sampler = CPUSampler.find(engine);
+            int nThreads = 5;
+            int nSamples = 5;
+            Map<Thread, RootCounter> threads = new ConcurrentHashMap<>();
+            List<Future<?>> futures = new ArrayList<>();
+            CountDownLatch fibLatch = new CountDownLatch(nThreads);
+            Source src1 = Source.newBuilder("sl", FIB_15_PLUS, "fib15plus.sl").build();
+            Source src2 = Source.newBuilder("sl", FIB, "fib.sl").build();
+            for (int i = 0; i < nThreads; i++) {
+                futures.add(executorService.submit(() -> {
+                    threads.putIfAbsent(Thread.currentThread(), new RootCounter());
+                    AtomicBoolean countedDown = new AtomicBoolean();
+                    while (runFlag.get()) {
+                        try (Context context1 = Context.newBuilder().engine(engine).build(); Context context2 = Context.newBuilder().engine(engine).build()) {
+                            Value fib15plus = context1.eval(src1);
+                            Value fib = context2.eval(src2);
+                            ProxyExecutable proxyExecutable = (n) -> {
+                                if (countedDown.compareAndSet(false, true)) {
+                                    fibLatch.countDown();
+                                }
+                                return fib.execute((Object[]) n);
+                            };
+                            Assert.assertEquals(514229, fib15plus.execute(29, proxyExecutable).asInt());
+                        }
+                    }
+                }));
+            }
+            fibLatch.await();
+            for (int i = 0; i < nSamples; i++) {
+                Map<Thread, List<StackTraceEntry>> sample = sampler.takeSample();
+                for (Map.Entry<Thread, List<StackTraceEntry>> sampleEntry : sample.entrySet()) {
+                    RootCounter rootCounter = threads.get(sampleEntry.getKey());
+                    for (StackTraceEntry stackTraceEntry : sampleEntry.getValue()) {
+                        if ("fib".equals(stackTraceEntry.getRootName())) {
+                            rootCounter.fibCount++;
+                        }
+                        if ("fib15plus".equals(stackTraceEntry.getRootName())) {
+                            rootCounter.fib15plusCount++;
+                        }
+                    }
+                }
+            }
+            runFlag.set(false);
+            for (Future<?> future : futures) {
+                future.get();
+            }
+            for (Map.Entry<Thread, RootCounter> threadEntry : threads.entrySet()) {
+                Assert.assertTrue(nSamples + " samples should contain at least 1 occurrence of the fib root for each thread, but one thread contained only " + threadEntry.getValue().fibCount,
+                                threadEntry.getValue().fibCount > 1);
+                Assert.assertTrue(nSamples + " samples should contain at least 10 occurrences of the fib15plus root, but one thread contained only " + threadEntry.getValue().fib15plusCount,
+                                threadEntry.getValue().fib15plusCount > 10);
+            }
+        }
+    }
+}

--- a/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/CPUSamplerTest.java
+++ b/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/CPUSamplerTest.java
@@ -87,7 +87,7 @@ public class CPUSamplerTest extends AbstractProfilerTest {
         context.initialize(ProxyLanguage.ID);
         sampler.setCollecting(false);
 
-        Map<TruffleContext, CPUSamplerData> data = sampler.getData();
+        List<CPUSamplerData> data = sampler.getDataList();
         assertEquals(1, data.size());
 
         assertEquals(0, searchInitializeContext(data).size());
@@ -113,15 +113,15 @@ public class CPUSamplerTest extends AbstractProfilerTest {
         context.initialize(ProxyLanguage.ID);
         sampler.setCollecting(false);
 
-        Map<TruffleContext, CPUSamplerData> data = sampler.getData();
+        List<CPUSamplerData> data = sampler.getDataList();
         assertEquals(1, data.size());
 
         assertEquals(0, searchInitializeContext(data).size());
     }
 
-    private static List<ProfilerNode<Payload>> searchInitializeContext(Map<TruffleContext, CPUSamplerData> data) {
+    private static List<ProfilerNode<Payload>> searchInitializeContext(List<CPUSamplerData> data) {
         List<ProfilerNode<Payload>> found = new ArrayList<>();
-        for (CPUSamplerData d : data.values()) {
+        for (CPUSamplerData d : data) {
             Map<Thread, Collection<ProfilerNode<Payload>>> threadData = d.getThreadData();
             assertEquals(threadData.toString(), 1, threadData.size());
 
@@ -146,8 +146,8 @@ public class CPUSamplerTest extends AbstractProfilerTest {
     public void testCollectingAndHasData() {
 
         sampler.setCollecting(true);
-        Map<TruffleContext, CPUSamplerData> before = sampler.getData();
-        Assert.assertEquals(0, before.values().iterator().next().getSamples());
+        List<CPUSamplerData> before = sampler.getDataList();
+        Assert.assertEquals(0, before.iterator().next().getSamples());
         Assert.assertTrue(sampler.isCollecting());
         Assert.assertFalse(sampler.hasData());
 
@@ -155,8 +155,8 @@ public class CPUSamplerTest extends AbstractProfilerTest {
             eval(defaultSourceForSampling);
         }
 
-        Map<TruffleContext, CPUSamplerData> after = sampler.getData();
-        Assert.assertNotEquals(0, after.values().iterator().next().getSamples());
+        List<CPUSamplerData> after = sampler.getDataList();
+        Assert.assertNotEquals(0, after.iterator().next().getSamples());
         Assert.assertTrue(sampler.isCollecting());
         Assert.assertTrue(sampler.hasData());
 
@@ -166,9 +166,9 @@ public class CPUSamplerTest extends AbstractProfilerTest {
         Assert.assertTrue(sampler.hasData());
 
         sampler.clearData();
-        Map<TruffleContext, CPUSamplerData> cleared = sampler.getData();
+        List<CPUSamplerData> cleared = sampler.getDataList();
         Assert.assertFalse(sampler.isCollecting());
-        Assert.assertEquals(0, cleared.values().iterator().next().getSamples());
+        Assert.assertEquals(0, cleared.iterator().next().getSamples());
 
         Assert.assertFalse(sampler.hasData());
     }
@@ -221,9 +221,9 @@ public class CPUSamplerTest extends AbstractProfilerTest {
     }
 
     private Collection<ProfilerNode<Payload>> getProfilerNodes() {
-        Map<TruffleContext, CPUSamplerData> data = sampler.getData();
+        List<CPUSamplerData> data = sampler.getDataList();
         Assert.assertEquals(1, data.size());
-        Map<Thread, Collection<ProfilerNode<Payload>>> threadData = data.values().iterator().next().getThreadData();
+        Map<Thread, Collection<ProfilerNode<Payload>>> threadData = data.iterator().next().getThreadData();
         Assert.assertEquals(1, threadData.size());
         Collection<ProfilerNode<Payload>> children = threadData.values().iterator().next();
         return children;
@@ -334,6 +334,7 @@ public class CPUSamplerTest extends AbstractProfilerTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testTiers() {
         Assume.assumeFalse(Truffle.getRuntime().getClass().toString().contains("Default"));
         Context.Builder builder = Context.newBuilder().option("engine.FirstTierCompilationThreshold", Integer.toString(FIRST_TIER_THRESHOLD)).option("engine.LastTierCompilationThreshold",
@@ -345,6 +346,7 @@ public class CPUSamplerTest extends AbstractProfilerTest {
             for (int i = 0; i < 3 * FIRST_TIER_THRESHOLD; i++) {
                 c.eval(defaultSourceForSampling);
             }
+            // Intentionally kept one usage of the deprecated API
             data = cpuSampler.getData();
         }
         CPUSamplerData samplerData = data.values().iterator().next();

--- a/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/ProfilerCLITest.java
+++ b/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/ProfilerCLITest.java
@@ -31,9 +31,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.oracle.truffle.api.Truffle;
-import com.oracle.truffle.api.TruffleContext;
-import com.oracle.truffle.tools.profiler.CPUSamplerData;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Source;
 import org.graalvm.shadowed.org.json.JSONArray;
@@ -43,9 +40,11 @@ import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.instrumentation.test.InstrumentationTestLanguage;
 import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.tools.profiler.CPUSampler;
+import com.oracle.truffle.tools.profiler.CPUSamplerData;
 import com.oracle.truffle.tools.profiler.ProfilerNode;
 
 public class ProfilerCLITest {
@@ -364,8 +363,8 @@ public class ProfilerCLITest {
         final long sampleCount;
         final boolean gatherSelfHitTimes;
         synchronized (sampler) {
-            Map<TruffleContext, CPUSamplerData> data = sampler.getData();
-            CPUSamplerData samplerData = data.values().iterator().next();
+            List<CPUSamplerData> data = sampler.getDataList();
+            CPUSamplerData samplerData = data.iterator().next();
             threadToNodesMap = samplerData.getThreadData();
             period = sampler.getPeriod();
             sampleCount = samplerData.getSamples();

--- a/tools/src/com.oracle.truffle.tools.profiler/snapshot.sigtest
+++ b/tools/src/com.oracle.truffle.tools.profiler/snapshot.sigtest
@@ -10,7 +10,9 @@ meth public boolean isCollecting()
 meth public boolean isGatherSelfHitTimes()
 meth public com.oracle.truffle.api.instrumentation.SourceSectionFilter getFilter()
 meth public int getStackLimit()
+meth public java.util.List<com.oracle.truffle.tools.profiler.CPUSamplerData> getDataList()
 meth public java.util.Map<com.oracle.truffle.api.TruffleContext,com.oracle.truffle.tools.profiler.CPUSamplerData> getData()
+ anno 0 java.lang.Deprecated(boolean forRemoval=false, java.lang.String since="")
 meth public java.util.Map<java.lang.Thread,java.util.List<com.oracle.truffle.tools.profiler.StackTraceEntry>> takeSample()
 meth public java.util.Map<java.lang.Thread,java.util.List<com.oracle.truffle.tools.profiler.StackTraceEntry>> takeSample(long,java.util.concurrent.TimeUnit)
 meth public long getPeriod()
@@ -25,8 +27,8 @@ meth public void setPeriod(long)
 meth public void setSampleContextInitialization(boolean)
 meth public void setStackLimit(int)
 supr java.lang.Object
-hfds COPY_PAYLOAD,DEFAULT_FILTER,activeContexts,closed,collecting,delay,env,filter,gatherSelfHitTimes,period,processingThread,processingThreadRunnable,resultsToProcess,safepointStackSampler,sampleContextInitialization,samplerTask,samplerThread,stackLimit
-hcls MutableSamplerData,ResultProcessingRunnable,SamplingResult,SamplingTimerTask
+hfds COPY_PAYLOAD,DEFAULT_FILTER,activeContexts,closed,collecting,delay,env,filter,gatherSelfHitTimes,nextContextIndex,period,processingExecutionService,processingThreadFuture,processingThreadRunnable,resultsToProcess,safepointStackSampler,sampleContextInitialization,samplerData,samplerExecutionService,samplerFuture,stackLimit
+hcls MutableSamplerData,ResultProcessingRunnable,SamplingResult,SamplingTask
 
 CLSS public final static com.oracle.truffle.tools.profiler.CPUSampler$Payload
  outer com.oracle.truffle.tools.profiler.CPUSampler
@@ -41,6 +43,8 @@ hfds selfHitTimes,selfTierCount,tierCount
 
 CLSS public final com.oracle.truffle.tools.profiler.CPUSamplerData
 meth public com.oracle.truffle.api.TruffleContext getContext()
+ anno 0 java.lang.Deprecated(boolean forRemoval=false, java.lang.String since="")
+meth public int getContextIndex()
 meth public java.util.LongSummaryStatistics getSampleBias()
 meth public java.util.LongSummaryStatistics getSampleDuration()
 meth public java.util.Map<java.lang.Thread,java.util.Collection<com.oracle.truffle.tools.profiler.ProfilerNode<com.oracle.truffle.tools.profiler.CPUSampler$Payload>>> getThreadData()
@@ -48,7 +52,7 @@ meth public long getSampleInterval()
 meth public long getSamples()
 meth public long missedSamples()
 supr java.lang.Object
-hfds biasStatistics,context,durationStatistics,intervalMs,missedSamples,samplesTaken,threadData
+hfds biasStatistics,contextIndex,durationStatistics,intervalMs,missedSamples,samplesTaken,threadData
 
 CLSS public final com.oracle.truffle.tools.profiler.CPUTracer
 innr public final static Payload
@@ -87,7 +91,7 @@ meth public void clearData()
 meth public void close()
 meth public void setCollecting(boolean)
 supr java.lang.Object
-hfds CLEAN_INTERVAL,INTEROP,RECURSIVE,activeBinding,closed,collecting,env,initializedLanguages,newReferences,processedReferences,referenceQueue,referenceThread,summaryData
+hfds CLEAN_INTERVAL,INTEROP,RECURSIVE,activeBinding,closed,collecting,env,initializedLanguages,newReferences,processedReferences,referenceExecutorService,referenceFuture,referenceQueue,summaryData
 hcls Listener,ObjectWeakReference
 
 CLSS public final com.oracle.truffle.tools.profiler.HeapSummary
@@ -177,7 +181,7 @@ CLSS public java.lang.Object
 cons public init()
 meth protected java.lang.Object clone() throws java.lang.CloneNotSupportedException
 meth protected void finalize() throws java.lang.Throwable
- anno 0 java.lang.Deprecated(boolean forRemoval=false, java.lang.String since="9")
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="9")
 meth public boolean equals(java.lang.Object)
 meth public final java.lang.Class<?> getClass()
 meth public final void notify()

--- a/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/SVGSamplerOutput.java
+++ b/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/SVGSamplerOutput.java
@@ -24,31 +24,32 @@
  */
 package com.oracle.truffle.tools.profiler.impl;
 
-import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.api.source.SourceSection;
-import com.oracle.truffle.api.TruffleContext;
-import com.oracle.truffle.tools.profiler.CPUSampler;
-import com.oracle.truffle.tools.profiler.CPUSamplerData;
-import com.oracle.truffle.tools.profiler.ProfilerNode;
-import org.graalvm.shadowed.org.json.JSONArray;
-import org.graalvm.shadowed.org.json.JSONObject;
-
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Scanner;
 
+import org.graalvm.shadowed.org.json.JSONArray;
+import org.graalvm.shadowed.org.json.JSONObject;
+
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.tools.profiler.CPUSampler;
+import com.oracle.truffle.tools.profiler.CPUSamplerData;
+import com.oracle.truffle.tools.profiler.ProfilerNode;
+
 final class SVGSamplerOutput {
 
-    public static void printSamplingFlameGraph(PrintStream out, Map<TruffleContext, CPUSamplerData> data) {
+    public static void printSamplingFlameGraph(PrintStream out, List<CPUSamplerData> data) {
         GraphOwner graph = new GraphOwner(new StringBuilder(), data);
 
         graph.addComponent(new SVGFlameGraph(graph));
@@ -68,7 +69,7 @@ final class SVGSamplerOutput {
     public void header(double width, double height) {
         output.append("<?xml version=\"1.0\" standalone=\"no\"?>\n");
         output.append("<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n");
-        output.append(String.format(
+        output.append(String.format(Locale.ROOT,
                         "<svg version=\"1.1\" width=\"%1$f\" height=\"%2$f\" onload=\"init(evt)\" viewBox=\"0 0 %1$f %2$f\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
                         width, height));
     }
@@ -78,7 +79,7 @@ final class SVGSamplerOutput {
     }
 
     public static String allocateColor(int r, int g, int b) {
-        return String.format("rgb(%d, %d, %d)", r, g, b);
+        return String.format(Locale.ROOT, "rgb(%d, %d, %d)", r, g, b);
     }
 
     public static String startGroup(Map<String, String> attributes) {
@@ -86,7 +87,7 @@ final class SVGSamplerOutput {
         result.append("<g ");
         for (String key : new String[]{"class", "style", "onmouseover", "onmouseout", "onclick", "id"}) {
             if (attributes.containsKey(key)) {
-                result.append(String.format("%s=\"%s\"", key, attributes.get(key)));
+                result.append(String.format(Locale.ROOT, "%s=\"%s\"", key, attributes.get(key)));
                 result.append(" ");
             }
         }
@@ -97,11 +98,11 @@ final class SVGSamplerOutput {
         }
 
         if (attributes.containsKey("title")) {
-            result.append(String.format("<title>%s</title>", attributes.get("title")));
+            result.append(String.format(Locale.ROOT, "<title>%s</title>", attributes.get("title")));
         }
 
         if (attributes.containsKey("href")) {
-            result.append(String.format("<a xlink:href=%s", attributes.get("href")));
+            result.append(String.format(Locale.ROOT, "<a xlink:href=%s", attributes.get("href")));
 
             final String target;
             if (attributes.containsKey("target")) {
@@ -109,7 +110,7 @@ final class SVGSamplerOutput {
             } else {
                 target = "_top";
             }
-            result.append(String.format(" target=%s", target));
+            result.append(String.format(Locale.ROOT, " target=%s", target));
         }
         return result.toString();
     }
@@ -127,7 +128,7 @@ final class SVGSamplerOutput {
         StringBuilder result = new StringBuilder();
         result.append("<svg ");
         for (Map.Entry<String, String> e : attributes.entrySet()) {
-            result.append(String.format("%s=\"%s\"", e.getKey(), e.getValue()));
+            result.append(String.format(Locale.ROOT, "%s=\"%s\"", e.getKey(), e.getValue()));
             result.append(" ");
         }
         result.append(">\n");
@@ -143,16 +144,17 @@ final class SVGSamplerOutput {
 
     public static String fillRectangle(double x1, double y1, double w, double h, String fill, String extras, Map<String, String> attributes) {
         StringBuilder result = new StringBuilder();
-        result.append(String.format("<rect x=\"%f\" y=\"%f\" width=\"%f\" height=\"%f\" fill=\"%s\" %s", x1, y1, w, h, fill, extras));
+        result.append(String.format(Locale.ROOT, "<rect x=\"%f\" y=\"%f\" width=\"%f\" height=\"%f\" fill=\"%s\" %s", x1, y1, w, h, fill, extras));
         for (Map.Entry<String, String> entry : attributes.entrySet()) {
-            result.append(String.format(" %s=\"%s\"", entry.getKey(), entry.getValue()));
+            result.append(String.format(Locale.ROOT, " %s=\"%s\"", entry.getKey(), entry.getValue()));
         }
         result.append("/>\n");
         return result.toString();
     }
 
     public static String ttfString(String color, String font, double size, double x, double y, String text, String loc, String extras) {
-        return String.format("<text text-anchor=\"%s\" x=\"%f\" y=\"%f\" font-size=\"%f\" font-family=\"%s\" fill=\"%s\" %s >%s</text>\n", loc == null ? "left" : loc, x, y, size, font, color,
+        return String.format(Locale.ROOT, "<text text-anchor=\"%s\" x=\"%f\" y=\"%f\" font-size=\"%f\" font-family=\"%s\" fill=\"%s\" %s >%s</text>\n", loc == null ? "left" : loc, x, y, size, font,
+                        color,
                         extras == null ? "" : extras, escape(text));
     }
 
@@ -212,7 +214,7 @@ final class SVGSamplerOutput {
     private static class GraphOwner implements SVGComponent {
 
         private final SVGSamplerOutput svg;
-        private final Map<TruffleContext, CPUSamplerData> data;
+        private final List<CPUSamplerData> data;
         private ArrayList<SVGComponent> components;
         private Random random = new Random();
         private Map<GraphColorMap, String> languageColors;
@@ -230,7 +232,7 @@ final class SVGSamplerOutput {
         public final JSONArray sampleJsonKeys = new JSONArray();
         public final JSONArray sampleData = new JSONArray();
 
-        GraphOwner(StringBuilder output, Map<TruffleContext, CPUSamplerData> data) {
+        GraphOwner(StringBuilder output, List<CPUSamplerData> data) {
             svg = new SVGSamplerOutput(output);
             this.data = data;
             components = new ArrayList<>();
@@ -267,8 +269,8 @@ final class SVGSamplerOutput {
             StringBuilder css = new StringBuilder();
             css.append("<defs>\n");
             css.append("    <linearGradient id=\"background\" y1=\"0\" y2=\"1\" x1=\"0\" x2=\"0\" >\n");
-            css.append(String.format("        <stop stop-color=\"%s\" offset=\"5%%\" />\n", background1()));
-            css.append(String.format("        <stop stop-color=\"%s\" offset=\"95%%\" />\n", background2()));
+            css.append(String.format(Locale.ROOT, "        <stop stop-color=\"%s\" offset=\"5%%\" />\n", background1()));
+            css.append(String.format(Locale.ROOT, "        <stop stop-color=\"%s\" offset=\"95%%\" />\n", background2()));
             css.append("    </linearGradient>\n");
             css.append("</defs>\n");
             css.append("<style type=\"text/css\">\n");
@@ -285,8 +287,8 @@ final class SVGSamplerOutput {
             result.append("<script type=\"text/ecmascript\">\n<![CDATA[\n");
             result.append(getResource("graphowner.js"));
             result.append("'use strict';\n");
-            result.append(String.format("var fontSize = %s;\n", fontSize()));
-            result.append(String.format("var fontWidth = %s;\n", fontWidth()));
+            result.append(String.format(Locale.ROOT, "var fontSize = %s;\n", fontSize()));
+            result.append(String.format(Locale.ROOT, "var fontWidth = %s;\n", fontWidth()));
             result.append(samples());
             result.append(resizeFunction());
             result.append(initFunction("evt"));
@@ -326,7 +328,7 @@ final class SVGSamplerOutput {
             root.put("l", GraphColorMap.GRAY.ordinal());
             long totalSamples = 0;
             JSONArray children = new JSONArray();
-            for (CPUSamplerData value : data.values()) {
+            for (CPUSamplerData value : data) {
                 for (Map.Entry<Thread, Collection<ProfilerNode<CPUSampler.Payload>>> node : value.getThreadData().entrySet()) {
                     Thread thread = node.getKey();
                     // Output the thread node itself...
@@ -663,7 +665,7 @@ final class SVGSamplerOutput {
 
         public String initFunction(String argName) {
             StringBuilder result = new StringBuilder();
-            result.append(String.format("function init(%s) {\n", argName));
+            result.append(String.format(Locale.ROOT, "function init(%s) {\n", argName));
             for (SVGComponent component : components) {
                 result.append(component.initFunction(argName));
             }
@@ -686,10 +688,10 @@ final class SVGSamplerOutput {
 
         public String searchFunction(String argName) {
             StringBuilder result = new StringBuilder();
-            result.append(String.format("var searchColor = \"%s\";\n", searchColor()));
+            result.append(String.format(Locale.ROOT, "var searchColor = \"%s\";\n", searchColor()));
             result.append(getResource("search.js"));
 
-            result.append(String.format("function search(%s) {\n", argName));
+            result.append(String.format(Locale.ROOT, "function search(%s) {\n", argName));
             for (SVGComponent component : components) {
                 result.append(component.searchFunction(argName));
             }
@@ -926,8 +928,8 @@ final class SVGSamplerOutput {
 
         public String script() {
             StringBuilder script = new StringBuilder();
-            script.append(String.format("var xpad = %s;\nvar fg_width = 1200;\nvar fg_bottom_padding = %s;\nvar fg_min_width = %s;\n", XPAD, bottomPadding, MINWIDTH));
-            script.append(String.format("var fg_frameheight = %s;\nvar fg_top_padding = %s;", FRAMEHEIGHT, topPadding));
+            script.append(String.format(Locale.ROOT, "var xpad = %s;\nvar fg_width = 1200;\nvar fg_bottom_padding = %s;\nvar fg_min_width = %s;\n", XPAD, bottomPadding, MINWIDTH));
+            script.append(String.format(Locale.ROOT, "var fg_frameheight = %s;\nvar fg_top_padding = %s;", FRAMEHEIGHT, topPadding));
             script.append(owner.getResource("flamegraph.js"));
             return script.toString();
         }
@@ -939,7 +941,7 @@ final class SVGSamplerOutput {
             svgattr.put("y", Double.toString(y));
             svgattr.put("wdith", Double.toString(width()));
             svgattr.put("height", Double.toString(height()));
-            svgattr.put("viewBox", String.format("0.0 -%f %f %f", height(), width(), height()));
+            svgattr.put("viewBox", String.format(Locale.ROOT, "0.0 -%f %f %f", height(), width(), height()));
             output.append(startSubDrawing(svgattr));
             Map<String, String> attr = new HashMap<>();
             Map<String, String> canvasAttr = new HashMap<>();
@@ -1038,9 +1040,9 @@ final class SVGSamplerOutput {
             int total = sample.getInt("h");
             double percent = 100.0 * (compiled + interpreted) / sampleCount;
             double totalPercent = 100.0 * total / sampleCount;
-            title.append(String.format("Self samples: %d (%.2f%%)\n", interpreted + compiled, percent));
-            title.append(String.format("total samples:  %d (%.2f%%)\n", total, totalPercent));
-            title.append(String.format("Source location: %s:%d\n", owner.sourceNames.get(key.sourceId), key.sourceLine));
+            title.append(String.format(Locale.ROOT, "Self samples: %d (%.2f%%)\n", interpreted + compiled, percent));
+            title.append(String.format(Locale.ROOT, "total samples:  %d (%.2f%%)\n", total, totalPercent));
+            title.append(String.format(Locale.ROOT, "Source location: %s:%d\n", owner.sourceNames.get(key.sourceId), key.sourceLine));
             groupAttrs.put("title", escape(title.toString()));
             output.append(startGroup(groupAttrs));
 
@@ -1073,11 +1075,11 @@ final class SVGSamplerOutput {
         }
 
         public String initFunction(String argName) {
-            return String.format("fg_init(%s)\n", argName);
+            return String.format(Locale.ROOT, "fg_init(%s)\n", argName);
         }
 
         public String searchFunction(String argName) {
-            return String.format("fg_search(%s)\n", argName);
+            return String.format(Locale.ROOT, "fg_search(%s)\n", argName);
         }
 
         public String resetSearchFunction() {
@@ -1157,11 +1159,11 @@ final class SVGSamplerOutput {
 
         public String script() {
             StringBuilder script = new StringBuilder();
-            script.append(String.format("var h_width = %s;\n", width()));
-            script.append(String.format("var h_minwidth = %s;\n", MINWIDTH));
-            script.append(String.format("var h_top_padding = %s;\n", titlePadding));
-            script.append(String.format("var h_bottom_padding = %s;\n", bottomPadding));
-            script.append(String.format("var h_frameheight = %s;\n", FRAMEHEIGHT));
+            script.append(String.format(Locale.ROOT, "var h_width = %s;\n", width()));
+            script.append(String.format(Locale.ROOT, "var h_minwidth = %s;\n", MINWIDTH));
+            script.append(String.format(Locale.ROOT, "var h_top_padding = %s;\n", titlePadding));
+            script.append(String.format(Locale.ROOT, "var h_bottom_padding = %s;\n", bottomPadding));
+            script.append(String.format(Locale.ROOT, "var h_frameheight = %s;\n", FRAMEHEIGHT));
             script.append("var histogramData = ");
             JSONArray data = new JSONArray();
             for (JSONObject bar : histogram) {
@@ -1180,7 +1182,7 @@ final class SVGSamplerOutput {
             svgattr.put("y", Double.toString(y));
             svgattr.put("wdith", Double.toString(width()));
             svgattr.put("height", Double.toString(height()));
-            svgattr.put("viewBox", String.format("0.0 0.0 %f %f", width(), height()));
+            svgattr.put("viewBox", String.format(Locale.ROOT, "0.0 0.0 %f %f", width(), height()));
             output.append(startSubDrawing(svgattr));
             Map<String, String> attr = new HashMap<>();
             Map<String, String> canvasAttr = new HashMap<>();
@@ -1222,9 +1224,9 @@ final class SVGSamplerOutput {
             title.append("\n");
             int interpreted = bar.getInt("i");
             int compiled = bar.getInt("c");
-            title.append(String.format("%d samples (%d interpreted, %d compiled).\n", interpreted + compiled, interpreted, compiled));
+            title.append(String.format(Locale.ROOT, "%d samples (%d interpreted, %d compiled).\n", interpreted + compiled, interpreted, compiled));
             double percent = 100.0 * (compiled + interpreted) / sampleCount;
-            title.append(String.format("%.2f%% of displayed samples.\n", percent));
+            title.append(String.format(Locale.ROOT, "%.2f%% of displayed samples.\n", percent));
             groupAttrs.put("title", escape(title.toString()));
             output.append(startGroup(groupAttrs));
 
@@ -1269,11 +1271,11 @@ final class SVGSamplerOutput {
         }
 
         public String initFunction(String argName) {
-            return String.format("h_init(%s)\n", argName);
+            return String.format(Locale.ROOT, "h_init(%s)\n", argName);
         }
 
         public String searchFunction(String argName) {
-            return String.format("h_search(%s)\n", argName);
+            return String.format(Locale.ROOT, "h_search(%s)\n", argName);
         }
 
         public String resetSearchFunction() {

--- a/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/resources/flamegraph.js
+++ b/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/resources/flamegraph.js
@@ -78,7 +78,7 @@ function fg_create_element_for_sample(sample, width, x) {
     t.style.textAnchor = "left";
     t.setAttribute("x", x + 3);
     t.setAttribute("y", y - 5 + fg_frameheight);
-    t.style.fontSize = fontSize;
+    t.style.fontSize = fontSize + "px";
     t.style.fontFamily = "Verdana";
     t.style.fill = "rgb(0, 0, 0)";
 

--- a/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/resources/histogram.js
+++ b/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/resources/histogram.js
@@ -159,7 +159,7 @@ function h_create_element_for_id(id, bar, width) {
     t.style.textAnchor = "left";
     t.setAttribute("x", xpad + 3);
     t.setAttribute("y", y - 5 + fg_frameheight);
-    t.style.fontSize = fontSize;
+    t.style.fontSize = fontSize + "px";
     t.style.fontFamily = "Verdana";
     t.style.fill = "rgb(0, 0, 0)";
 

--- a/truffle/ci/ci.jsonnet
+++ b/truffle/ci/ci.jsonnet
@@ -160,7 +160,7 @@
 
     # BENCHMARKS
 
-    bench_hw.x52 + common.labsjdkLatestCE + bench_common + {
+    bench_hw.e3 + common.labsjdkLatestCE + bench_common + {
       name: "bench-truffle-jmh",
       notify_groups:: ["truffle_bench"],
       run: [

--- a/vm/ci/ci_common/common-bench.jsonnet
+++ b/vm/ci/ci_common/common-bench.jsonnet
@@ -40,6 +40,7 @@ local repo_config = import '../../../ci/repo-configuration.libsonnet';
       ENABLE_POLYBENCH_HPC: 'yes',
       POLYBENCH_HPC_EXTRA_HEADERS: '/cm/shared/apps/papi/papi-5.5.1/include',
       POLYBENCH_HPC_PAPI_LIB_DIR: '/cm/shared/apps/papi/papi-5.5.1/lib',
+      LIBPFM_FORCE_PMU: 'amd64'
     },
   },
 

--- a/vm/ci/ci_common/common-bench.jsonnet
+++ b/vm/ci/ci_common/common-bench.jsonnet
@@ -11,7 +11,7 @@ local repo_config = import '../../../ci/repo-configuration.libsonnet';
     result_file:: 'results.json',
     upload:: ['bench-uploader.py', self.result_file],
     upload_and_wait_for_indexing:: self.upload + ['--wait-for-indexing'],
-    capabilities+: ['tmpfs25g', 'x52'],
+    capabilities+: ['tmpfs25g', 'e3'],
     timelimit: '1:30:00',
   },
 
@@ -124,7 +124,7 @@ local repo_config = import '../../../ci/repo-configuration.libsonnet';
   },
 
   vm_bench_polybench_hpc_linux_common(env, metric, benchmarks='*', polybench_vm_config='native-interpreter'): self.vm_bench_polybench_linux_common(env=env) + self.polybench_hpc_linux_common + {
-    local machine_name = "x52",     // restricting ourselves to x52 machines since we know hardware performance counters work properly there
+    local machine_name = "e3",     // restricting ourselves to specific hardware to ensure performance counters work there
     machine_name_prefix:: "gate-",
     capabilities+: [machine_name],
     run+: [
@@ -232,7 +232,7 @@ local repo_config = import '../../../ci/repo-configuration.libsonnet';
     timelimit: '55:00',
   },
 
-  x52_js_bench_compilation_throughput(pgo): self.vm_bench_common + common.heap.default + {
+  js_bench_compilation_throughput(pgo): self.vm_bench_common + common.heap.default + {
     local mx_libgraal = ["mx", "--env", repo_config.vm.mx_env.libgraal],
 
     setup+: [
@@ -300,8 +300,8 @@ local repo_config = import '../../../ci/repo-configuration.libsonnet';
 
     vm_common.bench_daily_vm_linux_amd64 + self.vm_bench_polybench_nfi_linux_amd64 + vm.vm_java_21 + {name: 'daily-bench-vm-' + vm.vm_setup.short_name + '-polybench-nfi-java21-linux-amd64', notify_groups:: ['polybench']},
 
-    vm_common.bench_daily_vm_linux_amd64 + self.x52_js_bench_compilation_throughput(true) + vm.vm_java_21 + { name: 'daily-bench-vm-' + vm.vm_setup.short_name + '-libgraal-pgo-throughput-js-typescript-java' + self.jdk_version + '-linux-amd64' },
-    vm_common.bench_daily_vm_linux_amd64 + self.x52_js_bench_compilation_throughput(false) + vm.vm_java_21 + { name: 'daily-bench-vm-' + vm.vm_setup.short_name + '-libgraal-no-pgo-throughput-js-typescript-java' + self.jdk_version + '-linux-amd64' },
+    vm_common.bench_daily_vm_linux_amd64 + self.js_bench_compilation_throughput(true) + vm.vm_java_21 + { name: 'daily-bench-vm-' + vm.vm_setup.short_name + '-libgraal-pgo-throughput-js-typescript-java' + self.jdk_version + '-linux-amd64' },
+    vm_common.bench_daily_vm_linux_amd64 + self.js_bench_compilation_throughput(false) + vm.vm_java_21 + { name: 'daily-bench-vm-' + vm.vm_setup.short_name + '-libgraal-no-pgo-throughput-js-typescript-java' + self.jdk_version + '-linux-amd64' },
 
     vm_common.bench_daily_vm_linux_amd64 + self.vm_bench_js_linux_amd64() + {
       # Override `self.vm_bench_js_linux_amd64.run`

--- a/wasm/ci/ci_common/common.jsonnet
+++ b/wasm/ci/ci_common/common.jsonnet
@@ -180,7 +180,7 @@ local graal_suite_root = root_ci.graal_suite_root;
       ]
     ],
     logs: ['bench-results.json'],
-    capabilities+: ['x52'],
+    capabilities+: ['e3'],
     timelimit: '1:00:00',
   },
 


### PR DESCRIPTION
1st batch of https://github.com/graalvm/graalvm-community-jdk21u/issues/37

Backports:
* https://github.com/oracle/graal/pull/8516
* https://github.com/oracle/graal/pull/8477
* https://github.com/oracle/graal/pull/8658
* https://github.com/oracle/graal/pull/8578
* https://github.com/oracle/graal/pull/8749
* https://github.com/oracle/graal/pull/8808
* https://github.com/oracle/graal/pull/8536
* https://github.com/oracle/graal/pull/8722
* https://github.com/oracle/graal/pull/8879
* https://github.com/oracle/graal/pull/8759 (this is backported as a squashed commit see a5083fd85578172409e1eb9c6ff80939aab895c7)

> [!NOTE]
> `eed5f79a666 [GR-52780] Backport to 23.1: FileSystemsTest#testSetAttribute() fails on JDK-23-linux.` is not part of this backport because it has been separately backported in https://github.com/graalvm/graalvm-community-jdk21u/pull/20

The backports are clean, there were no conflicts.