### PR TITLE
Merge upstream vm-23.1.5 tag 8th batch

### DIFF
--- a/common.json
+++ b/common.json
@@ -19,12 +19,12 @@
     "labsjdk-ee-17-llvm": {"name": "labsjdk",   "version": "ee-17.0.8+2-jvmci-23.1-b02-sulong", "platformspecific": true },
 
     "oraclejdk21":        {"name": "jpg-jdk",   "version": "21",      "build_id": "33", "release": true, "platformspecific": true, "extrabundles": ["static-libs"]},
-    "labsjdk-ce-21":      {"name": "labsjdk",   "version": "ee-21.0.5+7-jvmci-23.1-b46", "platformspecific": true },
-    "labsjdk-ce-21Debug": {"name": "labsjdk",   "version": "ee-21.0.5+7-jvmci-23.1-b46-debug", "platformspecific": true },
-    "labsjdk-ce-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.5+7-jvmci-23.1-b46-sulong", "platformspecific": true },
-    "labsjdk-ee-21":      {"name": "labsjdk",   "version": "ee-21.0.5+7-jvmci-23.1-b46", "platformspecific": true },
-    "labsjdk-ee-21Debug": {"name": "labsjdk",   "version": "ee-21.0.5+7-jvmci-23.1-b46-debug", "platformspecific": true },
-    "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.5+7-jvmci-23.1-b46-sulong", "platformspecific": true },
+    "labsjdk-ce-21":      {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47", "platformspecific": true },
+    "labsjdk-ce-21Debug": {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47-debug", "platformspecific": true },
+    "labsjdk-ce-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47-sulong", "platformspecific": true },
+    "labsjdk-ee-21":      {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47", "platformspecific": true },
+    "labsjdk-ee-21Debug": {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47-debug", "platformspecific": true },
+    "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47-sulong", "platformspecific": true },
 
     "oraclejdk22":        {"name": "jpg-jdk",   "version": "22",      "build_id": "2", "release": true, "platformspecific": true, "extrabundles": ["static-libs"]}
   },

--- a/common.json
+++ b/common.json
@@ -19,12 +19,12 @@
     "labsjdk-ee-17-llvm": {"name": "labsjdk",   "version": "ee-17.0.8+2-jvmci-23.1-b02-sulong", "platformspecific": true },
 
     "oraclejdk21":        {"name": "jpg-jdk",   "version": "21",      "build_id": "33", "release": true, "platformspecific": true, "extrabundles": ["static-libs"]},
-    "labsjdk-ce-21":      {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47", "platformspecific": true },
-    "labsjdk-ce-21Debug": {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47-debug", "platformspecific": true },
-    "labsjdk-ce-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47-sulong", "platformspecific": true },
-    "labsjdk-ee-21":      {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47", "platformspecific": true },
-    "labsjdk-ee-21Debug": {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47-debug", "platformspecific": true },
-    "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.5+8-jvmci-23.1-b47-sulong", "platformspecific": true },
+    "labsjdk-ce-21":      {"name": "labsjdk",   "version": "ee-21.0.5+9-jvmci-23.1-b48", "platformspecific": true },
+    "labsjdk-ce-21Debug": {"name": "labsjdk",   "version": "ee-21.0.5+9-jvmci-23.1-b48-debug", "platformspecific": true },
+    "labsjdk-ce-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.5+9-jvmci-23.1-b48-sulong", "platformspecific": true },
+    "labsjdk-ee-21":      {"name": "labsjdk",   "version": "ee-21.0.5+9-jvmci-23.1-b48", "platformspecific": true },
+    "labsjdk-ee-21Debug": {"name": "labsjdk",   "version": "ee-21.0.5+9-jvmci-23.1-b48-debug", "platformspecific": true },
+    "labsjdk-ee-21-llvm": {"name": "labsjdk",   "version": "ee-21.0.5+9-jvmci-23.1-b48-sulong", "platformspecific": true },
 
     "oraclejdk22":        {"name": "jpg-jdk",   "version": "22",      "build_id": "2", "release": true, "platformspecific": true, "extrabundles": ["static-libs"]}
   },

--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/SubprocessTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/test/SubprocessTest.java
@@ -24,12 +24,14 @@
  */
 package org.graalvm.compiler.core.test;
 
+import static org.graalvm.compiler.test.SubprocessUtil.getProcessCommandLine;
 import static org.graalvm.compiler.test.SubprocessUtil.getVMCommandLine;
 import static org.graalvm.compiler.test.SubprocessUtil.java;
 import static org.graalvm.compiler.test.SubprocessUtil.withoutDebuggerArguments;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -38,6 +40,23 @@ import org.graalvm.compiler.test.SubprocessUtil.Subprocess;
 import org.junit.Assume;
 import org.junit.Before;
 
+/**
+ * Utility class for executing Graal compiler tests in a subprocess. This can be useful for tests
+ * that need special VM arguments or that produce textual output or a special process termination
+ * status that need to be analyzed. The class to be executed may be the current class or any other
+ * unit test class.
+ * <p/>
+ * If the test class contains multiple {@code @Test} methods, they will all be executed in the
+ * subprocess, except when using one of the methods that take a {@code testSelector} argument. All
+ * methods in this class take a {@link Runnable} argument. If the test class is the same as the
+ * calling class, this runnable defines the operation to be executed in the subprocess. If the test
+ * class is not the same as the calling class, the runnable is irrelevant and can be a nop.
+ * <p/>
+ * The subprocess will inherit any {@code -JUnitVerbose} flag (typically set through
+ * {@code mx unittest --verbose}) from the parent process. If this flag is set, the standard output
+ * of the child process will be echoed to the standard output of the parent process. If the child
+ * process terminates with an error, its standard output will always be printed.
+ */
 public abstract class SubprocessTest extends GraalCompilerTest {
 
     @Before
@@ -54,16 +73,24 @@ public abstract class SubprocessTest extends GraalCompilerTest {
      *         {@link Subprocess} instance describing the process after its successful termination.
      */
     public SubprocessUtil.Subprocess launchSubprocess(Runnable runnable, String... args) throws InterruptedException, IOException {
-        return launchSubprocess(null, true, getClass(), runnable, args);
+        return launchSubprocess(null, true, getClass(), null, runnable, args);
     }
 
     public static SubprocessUtil.Subprocess launchSubprocess(Class<? extends GraalCompilerTest> testClass, Runnable runnable, String... args) throws InterruptedException, IOException {
-        return launchSubprocess(null, true, testClass, runnable, args);
+        return launchSubprocess(null, true, testClass, null, runnable, args);
     }
 
-    public static SubprocessUtil.Subprocess launchSubprocess(Predicate<List<String>> testPredicate, boolean expectNormalExit, Class<? extends GraalCompilerTest> testClass, Runnable runnable,
-                    String... args)
-                    throws InterruptedException, IOException {
+    public void launchSubprocess(String testSelector, Runnable runnable, String... args) throws InterruptedException, IOException {
+        launchSubprocess(null, true, getClass(), testSelector, runnable, args);
+    }
+
+    public static SubprocessUtil.Subprocess launchSubprocess(Predicate<List<String>> testPredicate, boolean expectNormalExit, Class<? extends GraalCompilerTest> testClass,
+                    Runnable runnable, String... args) throws InterruptedException, IOException {
+        return launchSubprocess(testPredicate, expectNormalExit, testClass, null, runnable, args);
+    }
+
+    public static SubprocessUtil.Subprocess launchSubprocess(Predicate<List<String>> testPredicate, boolean expectNormalExit, Class<? extends GraalCompilerTest> testClass, String testSelector,
+                    Runnable runnable, String... args) throws InterruptedException, IOException {
         String recursionPropName = testClass.getSimpleName() + ".Subprocess";
         if (Boolean.getBoolean(recursionPropName)) {
             runnable.run();
@@ -77,7 +104,18 @@ public abstract class SubprocessTest extends GraalCompilerTest {
             if (verbose) {
                 System.err.println(String.join(" ", vmArgs));
             }
-            SubprocessUtil.Subprocess proc = java(vmArgs, "com.oracle.mxtool.junit.MxJUnitWrapper", testClass.getName());
+            List<String> mainClassAndArgs = new LinkedList<>();
+            mainClassAndArgs.add("com.oracle.mxtool.junit.MxJUnitWrapper");
+            String testName = testClass.getName();
+            if (testSelector != null) {
+                testName += "#" + testSelector;
+            }
+            mainClassAndArgs.add(testName);
+            boolean junitVerbose = getProcessCommandLine().contains("-JUnitVerbose");
+            if (junitVerbose) {
+                mainClassAndArgs.add("-JUnitVerbose");
+            }
+            SubprocessUtil.Subprocess proc = java(vmArgs, mainClassAndArgs);
             if (testPredicate != null) {
                 assertTrue(testPredicate.test(proc.output), proc.toString() + " produced unexpected output:\n\n" + String.join("\n", proc.output));
             }
@@ -90,6 +128,13 @@ public abstract class SubprocessTest extends GraalCompilerTest {
                 assertTrue(proc.exitCode == 0, proc.toString() + " produced exit code " + proc.exitCode + ", but expected 0.");
             } else {
                 assertTrue(proc.exitCode != 0, proc.toString() + " produced normal exit code " + proc.exitCode + ", but expected abnormal exit.");
+            }
+            if (junitVerbose) {
+                System.out.println("--- subprocess output:");
+                for (String line : proc.output) {
+                    System.out.println(line);
+                }
+                System.out.println("--- end subprocess output");
             }
             return proc;
         }

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -484,11 +484,6 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
 
     public final int methodCompiledEntryOffset = getFieldOffset("Method::_from_compiled_entry", Integer.class, "address");
 
-    public final int invocationCounterOffset = getFieldOffset("MethodCounters::_invocation_counter", Integer.class, "InvocationCounter");
-    public final int backedgeCounterOffset = getFieldOffset("MethodCounters::_backedge_counter", Integer.class, "InvocationCounter");
-    public final int invocationCounterIncrement = getConstant("InvocationCounter::count_increment", Integer.class);
-    public final int invocationCounterShift = getConstant("InvocationCounter::count_shift", Integer.class);
-
     public final int compilationLevelFullOptimization = getConstant("CompLevel_full_optimization", Integer.class);
 
     public final int heapWordSize = getConstant("HeapWordSize", Integer.class);

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/replacements/HotSpotG1WriteBarrierSnippets.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/replacements/HotSpotG1WriteBarrierSnippets.java
@@ -58,7 +58,6 @@ import org.graalvm.word.WordFactory;
 
 import jdk.vm.ci.code.Register;
 import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.ResolvedJavaType;
 
 public final class HotSpotG1WriteBarrierSnippets extends G1WriteBarrierSnippets {
     public static final HotSpotForeignCallDescriptor G1WBPRECALL = new HotSpotForeignCallDescriptor(LEAF_NO_VZERO, REEXECUTABLE, KILLED_PRE_WRITE_BARRIER_STUB_LOCATIONS, "write_barrier_pre",
@@ -174,16 +173,6 @@ public final class HotSpotG1WriteBarrierSnippets extends G1WriteBarrierSnippets 
     @Override
     protected ForeignCallDescriptor printfCallDescriptor() {
         return Log.LOG_PRINTF;
-    }
-
-    @Override
-    protected ResolvedJavaType referenceType() {
-        return HotSpotReplacementsUtil.referenceType(INJECTED_METAACCESS);
-    }
-
-    @Override
-    protected long referentOffset() {
-        return HotSpotReplacementsUtil.referentOffset(INJECTED_METAACCESS);
     }
 
     public static class Templates extends AbstractTemplates {

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/replacements/HotSpotReplacementsUtil.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/replacements/HotSpotReplacementsUtil.java
@@ -383,26 +383,6 @@ public class HotSpotReplacementsUtil {
         return config.allocatePrefetchStepSize;
     }
 
-    @Fold
-    public static int invocationCounterIncrement(@InjectedParameter GraalHotSpotVMConfig config) {
-        return config.invocationCounterIncrement;
-    }
-
-    @Fold
-    public static int invocationCounterOffset(@InjectedParameter GraalHotSpotVMConfig config) {
-        return config.invocationCounterOffset;
-    }
-
-    @Fold
-    public static int backedgeCounterOffset(@InjectedParameter GraalHotSpotVMConfig config) {
-        return config.backedgeCounterOffset;
-    }
-
-    @Fold
-    public static int invocationCounterShift(@InjectedParameter GraalHotSpotVMConfig config) {
-        return config.invocationCounterShift;
-    }
-
     @NodeIntrinsic(value = KlassLayoutHelperNode.class)
     public static native int readLayoutHelper(KlassPointer object);
 
@@ -833,11 +813,6 @@ public class HotSpotReplacementsUtil {
 
     public static final LocationIdentity KLASS_MODIFIER_FLAGS_LOCATION = NamedLocationIdentity.immutable("Klass::_modifier_flags");
 
-    @Fold
-    public static int klassModifierFlagsOffset(@InjectedParameter GraalHotSpotVMConfig config) {
-        return config.klassModifierFlagsOffset;
-    }
-
     public static final LocationIdentity CLASS_KLASS_LOCATION = new HotSpotOptimizingLocationIdentity("Class._klass") {
         @Override
         public ValueNode canonicalizeRead(ValueNode read, ValueNode object, ValueNode location, CoreProviders tool) {
@@ -936,19 +911,12 @@ public class HotSpotReplacementsUtil {
         return "referent";
     }
 
-    @Fold
     public static long referentOffset(@InjectedParameter MetaAccessProvider metaAccessProvider) {
         return referentField(metaAccessProvider).getOffset();
     }
 
-    @Fold
     public static ResolvedJavaField referentField(@InjectedParameter MetaAccessProvider metaAccessProvider) {
-        return getField(referenceType(metaAccessProvider), referentFieldName());
-    }
-
-    @Fold
-    public static ResolvedJavaType referenceType(@InjectedParameter MetaAccessProvider metaAccessProvider) {
-        return metaAccessProvider.lookupJavaType(Reference.class);
+        return getField(metaAccessProvider.lookupJavaType(Reference.class), referentFieldName());
     }
 
     public static final LocationIdentity OBJ_ARRAY_KLASS_ELEMENT_KLASS_LOCATION = new HotSpotOptimizingLocationIdentity("ObjArrayKlass::_element_klass") {

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/stubs/ForeignCallSnippets.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/stubs/ForeignCallSnippets.java
@@ -111,16 +111,6 @@ public class ForeignCallSnippets implements Snippets {
         return object;
     }
 
-    @Fold
-    static long verifyOopMask(@InjectedParameter GraalHotSpotVMConfig config) {
-        return config.verifyOopMask;
-    }
-
-    @Fold
-    static long verifyOopBits(@InjectedParameter GraalHotSpotVMConfig config) {
-        return config.verifyOopBits;
-    }
-
     /**
      * Gets and clears the object result from a runtime call stored in a thread local.
      *

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/replacements/ReplacementsUtil.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/replacements/ReplacementsUtil.java
@@ -81,11 +81,6 @@ public final class ReplacementsUtil {
     }
 
     @Fold
-    public static int charArrayBaseOffset(@InjectedParameter MetaAccessProvider metaAccess) {
-        return metaAccess.getArrayBaseOffset(JavaKind.Char);
-    }
-
-    @Fold
     public static long charArrayIndexScale(@InjectedParameter MetaAccessProvider metaAccess) {
         return metaAccess.getArrayIndexScale(JavaKind.Char);
     }

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/replacements/gc/G1WriteBarrierSnippets.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/replacements/gc/G1WriteBarrierSnippets.java
@@ -69,8 +69,6 @@ import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordFactory;
 
-import jdk.vm.ci.meta.ResolvedJavaType;
-
 /**
  * Implementation of the write barriers for the G1 garbage collector.
  */
@@ -373,10 +371,6 @@ public abstract class G1WriteBarrierSnippets extends WriteBarrierSnippets implem
     protected abstract ForeignCallDescriptor validateObjectCallDescriptor();
 
     protected abstract ForeignCallDescriptor printfCallDescriptor();
-
-    protected abstract ResolvedJavaType referenceType();
-
-    protected abstract long referentOffset();
 
     protected boolean isTracingActive(int traceStartCycle) {
         return traceStartCycle > 0 && ((Pointer) WordFactory.pointer(gcTotalCollectionsAddress())).readInt(0) > traceStartCycle;

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/KnownTruffleTypes.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/KnownTruffleTypes.java
@@ -166,7 +166,6 @@ public class KnownTruffleTypes extends AbstractKnownTruffleTypes {
     public final ResolvedJavaField OptimizedCallTarget_rootNode = findField(OptimizedCallTarget, "rootNode");
 
     public final ResolvedJavaType OptimizedDirectCallNode = lookupTypeCached("com.oracle.truffle.runtime.OptimizedDirectCallNode");
-    public final ResolvedJavaField OptimizedDirectCallNode_currentCallTarget = findField(OptimizedDirectCallNode, "currentCallTarget");
     public final ResolvedJavaField OptimizedDirectCallNode_inliningForced = findField(OptimizedDirectCallNode, "inliningForced");
     public final ResolvedJavaField OptimizedDirectCallNode_callCount = findField(OptimizedDirectCallNode, "callCount");
 

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/AgnosticInliningPhase.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/AgnosticInliningPhase.java
@@ -87,7 +87,6 @@ public final class AgnosticInliningPhase extends BasePhase<TruffleTierContext> {
         if (scope != null) {
             scope.setCallTree(tree);
         }
-
         tree.dumpBasic("Before Inline");
         if (TruffleCompilerOptions.Inlining.getValue(context.compilerOptions)) {
             policy.run(tree);

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/GraphManager.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/GraphManager.java
@@ -154,7 +154,7 @@ final class GraphManager {
 
     static final class Entry {
         final StructuredGraph graph;
-        final EconomicSet<Invoke> invokeToTruffleCallNode;
+        final EconomicSet<Invoke> directInvokes;
         final List<Invoke> indirectInvokes;
         final boolean trivial;
         // Populated only when debug dump is enabled with debug dump level >= info.
@@ -164,9 +164,9 @@ final class GraphManager {
 
         Entry(StructuredGraph graph, PEAgnosticInlineInvokePlugin plugin, StructuredGraph graphAfterPEForDebugDump, int graphSize) {
             this.graph = graph;
-            this.invokeToTruffleCallNode = plugin.getInvokeToTruffleCallNode();
+            this.directInvokes = plugin.getDirectInvokes();
             this.indirectInvokes = plugin.getIndirectInvokes();
-            this.trivial = invokeToTruffleCallNode.isEmpty() &&
+            this.trivial = directInvokes.isEmpty() &&
                             indirectInvokes.isEmpty() &&
                             graph.getNodes(LoopBeginNode.TYPE).count() == 0 &&
                             graph.getNodeCount() < TRIVIAL_NODE_COUNT_LIMIT;

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
@@ -183,6 +183,12 @@ public class ObjectScanner {
 
         } catch (UnsupportedFeatureException ex) {
             unsupportedFeatureDuringFieldScan(bb, field, receiver, ex, reason);
+        } catch (AnalysisError analysisError) {
+            if (analysisError.getCause() instanceof UnsupportedFeatureException ex) {
+                unsupportedFeatureDuringFieldScan(bb, field, receiver, ex, reason);
+            } else {
+                throw analysisError;
+            }
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SecuritySubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SecuritySubstitutions.java
@@ -192,6 +192,18 @@ final class Target_java_security_Provider {
     private static Target_java_security_Provider_ServiceKey previousKey;
 }
 
+@TargetClass(value = java.security.Provider.class, innerClass = "Service")
+final class Target_java_security_Provider_Service {
+
+    /**
+     * The field is lazily initialized on first access. We already have the necessary reflection
+     * configuration for the reflective lookup at image run time.
+     */
+    @Alias //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    private Object constructorCache;
+}
+
 @Platforms(Platform.HOSTED_ONLY.class)
 class ServiceKeyComputer implements FieldValueTransformer {
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitor.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitor.java
@@ -43,7 +43,7 @@ import jdk.internal.misc.Unsafe;
 
 /**
  * {@link JavaMonitor} is based on the code of {@link java.util.concurrent.locks.ReentrantLock} as
- * of JDK 21+26.
+ * of JDK 24+11.
  *
  * Only the relevant methods from the JDK sources have been kept. Some additional Native
  * Image-specific functionality has been added.

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
@@ -40,7 +40,7 @@ import jdk.internal.misc.Unsafe;
 
 /**
  * {@link JavaMonitorQueuedSynchronizer} is based on the code of
- * {@link java.util.concurrent.locks.AbstractQueuedLongSynchronizer} as of JDK 21+26. This class
+ * {@link java.util.concurrent.locks.AbstractQueuedLongSynchronizer} as of JDK 24+11. This class
  * could be merged with {@link JavaMonitor} but we keep it separate because that way diffing against
  * the JDK sources is easier.
  * 
@@ -58,7 +58,7 @@ import jdk.internal.misc.Unsafe;
  * </ul>
  */
 abstract class JavaMonitorQueuedSynchronizer {
-    // Node.status field values
+    // Node status bits, also used as argument and return values
     static final int WAITING = 1; // must be 1
     static final int CANCELLED = 0x80000000; // must be negative
     static final int COND = 2; // in a condition wait
@@ -68,38 +68,38 @@ abstract class JavaMonitorQueuedSynchronizer {
 
     // see AbstractQueuedLongSynchronizer.Node
     abstract static class Node {
-        volatile Node prev;
-        volatile Node next;
-        Thread waiter;
-        volatile int status;
+        volatile Node prev; // initially attached via casTail
+        volatile Node next; // visibly nonnull when signallable
+        Thread waiter; // visibly nonnull when enqueued
+        volatile int status; // written by owner, atomic bit ops by others
 
         // see AbstractQueuedLongSynchronizer.Node.casPrev(Node, Node)
-        final boolean casPrev(Node c, Node v) {
+        final boolean casPrev(Node c, Node v) { // for cleanQueue
             return U.weakCompareAndSetReference(this, PREV, c, v);
         }
 
         // see AbstractQueuedLongSynchronizer.Node.casNext(Node, Node)
-        final boolean casNext(Node c, Node v) {
+        final boolean casNext(Node c, Node v) { // for cleanQueue
             return U.weakCompareAndSetReference(this, NEXT, c, v);
         }
 
         // see AbstractQueuedLongSynchronizer.Node.getAndUnsetStatus(int)
-        final int getAndUnsetStatus(int v) {
+        final int getAndUnsetStatus(int v) { // for signalling
             return U.getAndBitwiseAndInt(this, STATUS, ~v);
         }
 
         // see AbstractQueuedLongSynchronizer.Node.setPrevRelaxed(Node)
-        final void setPrevRelaxed(Node p) {
+        final void setPrevRelaxed(Node p) { // for off-queue assignment
             U.putReference(this, PREV, p);
         }
 
         // see AbstractQueuedLongSynchronizer.Node.setStatusRelaxed(int)
-        final void setStatusRelaxed(int s) {
+        final void setStatusRelaxed(int s) { // for off-queue assignment
             U.putInt(this, STATUS, s);
         }
 
         // see AbstractQueuedLongSynchronizer.Node.clearStatus()
-        final void clearStatus() {
+        final void clearStatus() { // for reducing unneeded signals
             U.putIntOpaque(this, STATUS, 0);
         }
 
@@ -114,7 +114,7 @@ abstract class JavaMonitorQueuedSynchronizer {
 
     // see AbstractQueuedLongSynchronizer.ConditionNode
     static final class ConditionNode extends Node {
-        ConditionNode nextWaiter;
+        ConditionNode nextWaiter; // link to next waiting node
         long notifierJfrTid;
 
         // see AbstractQueuedLongSynchronizer.ConditionNode.isReleasable()
@@ -148,16 +148,17 @@ abstract class JavaMonitorQueuedSynchronizer {
 
     // see AbstractQueuedLongSynchronizer.setState(long)
     protected final void setState(long newState) {
-        this.state = newState;
+        state = newState;
     }
 
     /**
-     * For {@linkplain JavaMonitorConditionObject#await conditional waiting}, returns the number of
-     * acquisitions, which is subsequently passed to {@link #tryRelease} to entirely release
-     * ownership, and later to {@link #tryAcquire} to regain ownership after waiting.
+     * Used for {@linkplain JavaMonitorConditionObject#await conditional waiting}. Returns the
+     * number of acquisitions, which is subsequently passed to {@link #tryRelease} to entirely
+     * release ownership, and later to {@link #tryAcquire} to regain ownership after waiting.
      *
-     * While {@code AbstractQueuedLongSynchronizer} calls {@link #getState()} assuming that it
-     * encodes the acquisition count, this method allows for more flexibility in implementations.
+     * Note that {@code AbstractQueuedLongSynchronizer} calls {@link #getState()} instead, assuming
+     * that the state encodes the acquisition count. This method allows for more flexibility in
+     * implementations.
      */
     protected abstract long getAcquisitions();
 
@@ -200,13 +201,13 @@ abstract class JavaMonitorQueuedSynchronizer {
             boolean unpark = false;
             for (Node t;;) {
                 if ((t = tail) == null && (t = tryInitializeHead()) == null) {
-                    unpark = true;             // wake up to spin on OOME
+                    unpark = true; // wake up to spin on OOME
                     break;
                 }
-                node.setPrevRelaxed(t);        // avoid unnecessary fence
+                node.setPrevRelaxed(t); // avoid unnecessary fence
                 if (casTail(t, node)) {
                     t.next = node;
-                    if (t.status < 0) {        // wake up to clean link
+                    if (t.status < 0) { // wake up to clean link
                         unpark = true;
                     }
                     break;
@@ -274,14 +275,15 @@ abstract class JavaMonitorQueuedSynchronizer {
         return (1 << parks) - 1;
     }
 
-    // see AbstractQueuedLongSynchronizer.acquire(Node, long, boolean, boolean, boolean, long)
+    // see AbstractQueuedLongSynchronizer.acquire(Node, long, false, false, false, 0L)
     @SuppressWarnings("all")
     final int acquire(Node node, long arg) {
         Thread current = Thread.currentThread();
+        /* Spinning logic is SVM-specific. */
         int parks = 0;
         int spins = getSpinAttempts(parks);
         boolean first = false;
-        Node pred = null;
+        Node pred = null; // predecessor of node when enqueued
 
         for (;;) {
             if (!first && (pred = (node == null) ? null : node.prev) != null && !(first = (head == pred))) {
@@ -297,6 +299,7 @@ abstract class JavaMonitorQueuedSynchronizer {
                 boolean acquired;
                 try {
                     if (spins > 0) {
+                        /* Spinning logic is SVM-specific. */
                         spins = trySpinAcquire(spins, arg);
                         acquired = (spins == SPIN_SUCCESS);
                         assert !acquired || isHeldExclusively();
@@ -318,11 +321,11 @@ abstract class JavaMonitorQueuedSynchronizer {
                 }
             }
             Node t;
-            if ((t = tail) == null) {           // initialize queue
+            if ((t = tail) == null) { // initialize queue
                 if (tryInitializeHead() == null) {
                     return acquireOnOOME(arg);
                 }
-            } else if (node == null) {          // allocate; retry before enqueue
+            } else if (node == null) { // allocate; retry before enqueue
                 try {
                     node = allocateExclusiveNode();
                 } catch (OutOfMemoryError oome) {
@@ -341,22 +344,28 @@ abstract class JavaMonitorQueuedSynchronizer {
             } else if (node.status == 0) {
                 node.status = WAITING; // enable signal and recheck
             } else {
+                /* Spinning logic is SVM-specific. */
                 parks++;
                 spins = getSpinAttempts(parks);
-                LockSupport.park(this);
+                try {
+                    LockSupport.park(this);
+                } catch (Error | RuntimeException ex) {
+                    cancelAcquire(node); // cancel & rethrow
+                    throw ex;
+                }
                 node.clearStatus();
             }
         }
     }
 
-    // see AbstractQueuedLongSynchronizer.acquireOnOOME(boolean, long)
+    // see AbstractQueuedLongSynchronizer.acquireOnOOME(false, long)
     private int acquireOnOOME(long arg) {
         for (long nanos = 1L;;) {
             if (tryAcquire(arg)) {
                 return 1;
             }
-            U.park(false, nanos);               // must use Unsafe park to sleep
-            if (nanos < 1L << 30) {             // max about 1 second
+            U.park(false, nanos); // must use Unsafe park to sleep
+            if (nanos < 1L << 30) { // max about 1 second
                 nanos <<= 1;
             }
         }
@@ -401,7 +410,7 @@ abstract class JavaMonitorQueuedSynchronizer {
         return new ExclusiveNode();
     }
 
-    // see AbstractQueuedLongSynchronizer.cancelAcquire(Node, boolean, boolean)
+    // see AbstractQueuedLongSynchronizer.cancelAcquire(Node, false, false)
     private int cancelAcquire(Node node) {
         if (node != null) {
             node.waiter = null;
@@ -445,23 +454,29 @@ abstract class JavaMonitorQueuedSynchronizer {
 
         static final long OOME_COND_WAIT_DELAY = 10L * 1000L * 1000L; // 10 ms
 
+        JavaMonitorConditionObject() {
+        }
+
         // see AbstractQueuedLongSynchronizer.ConditionObject.doSignal(ConditionNode, boolean)
         @SuppressWarnings("all")
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null) {
                     lastWaiter = null;
                 } else {
                     first.nextWaiter = null; // GC assistance
                 }
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
+                    /* JFR-related code is SVM-specific. */
                     first.notifierJfrTid = SubstrateJVM.getCurrentThreadId();
                     enqueue(first);
                     if (!all) {
                         break;
                     }
                 }
+
                 first = next;
             }
         }
@@ -566,6 +581,7 @@ abstract class JavaMonitorQueuedSynchronizer {
         // see AbstractQueuedLongSynchronizer.ConditionObject.await()
         @SuppressWarnings("all")
         public void await(Object obj) throws InterruptedException {
+            /* JFR-related code is SVM-specific. */
             long startTicks = JfrTicks.elapsedTicks();
             if (Thread.interrupted()) {
                 JavaMonitorWaitEvent.emit(startTicks, obj, 0, 0L, false);
@@ -605,6 +621,7 @@ abstract class JavaMonitorQueuedSynchronizer {
         // see AbstractQueuedLongSynchronizer.ConditionObject.await(long, TimeUnit)
         @SuppressWarnings("all")
         public boolean await(Object obj, long time, TimeUnit unit) throws InterruptedException {
+            /* JFR-related code is SVM-specific. */
             long startTicks = JfrTicks.elapsedTicks();
             long nanosTimeout = unit.toNanos(time);
             if (Thread.interrupted()) {
@@ -647,7 +664,7 @@ abstract class JavaMonitorQueuedSynchronizer {
 
     // Unsafe
     private static final Unsafe U = Unsafe.getUnsafe();
-    static final long STATE = U.objectFieldOffset(JavaMonitorQueuedSynchronizer.class, "state");
+    private static final long STATE = U.objectFieldOffset(JavaMonitorQueuedSynchronizer.class, "state");
     private static final long HEAD = U.objectFieldOffset(JavaMonitorQueuedSynchronizer.class, "head");
     private static final long TAIL = U.objectFieldOffset(JavaMonitorQueuedSynchronizer.class, "tail");
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/methodhandles/MethodHandleFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/methodhandles/MethodHandleFeature.java
@@ -294,20 +294,6 @@ public class MethodHandleFeature implements InternalFeature {
         }
     }
 
-<<<<<<< HEAD
-    private static String valueConverterName(Wrapper src, Wrapper dest) {
-        String srcType = src.primitiveSimpleName();
-        String destType = dest.primitiveSimpleName();
-        /* Capitalize first letter of destination type */
-        return srcType + "To" + destType.substring(0, 1).toUpperCase() + destType.substring(1);
-    }
-
-    private static void registerValueConversionIgnoreForReflection(DuringAnalysisAccess access) {
-        RuntimeReflection.register(ReflectionUtil.lookupMethod(ValueConversions.class, "ignore", Object.class));
-    }
-
-=======
->>>>>>> fb9b6c06c88 (Eagerly initialize caches in ValueConversions)
     private static void registerDelegatingMHFunctionsForReflection(DuringAnalysisAccess access) {
         Class<?> delegatingMHClazz = access.findClassByName("java.lang.invoke.DelegatingMethodHandle");
         RuntimeReflection.register(ReflectionUtil.lookupMethod(delegatingMHClazz, "getTarget"));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/methodhandles/MethodHandleFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/methodhandles/MethodHandleFeature.java
@@ -169,17 +169,7 @@ public class MethodHandleFeature implements InternalFeature {
         access.registerReachabilityHandler(MethodHandleFeature::registerInvokersFunctionsForReflection,
                         ReflectionUtil.lookupMethod(access.findClassByName("java.lang.invoke.Invokers"), "getFunction", byte.class));
 
-        access.registerReachabilityHandler(MethodHandleFeature::registerValueConversionBoxFunctionsForReflection,
-                        ReflectionUtil.lookupMethod(ValueConversions.class, "boxExact", Wrapper.class));
-
-        access.registerReachabilityHandler(MethodHandleFeature::registerValueConversionUnboxFunctionsForReflection,
-                        ReflectionUtil.lookupMethod(ValueConversions.class, "unbox", Wrapper.class, int.class));
-
-        access.registerReachabilityHandler(MethodHandleFeature::registerValueConversionConvertFunctionsForReflection,
-                        ReflectionUtil.lookupMethod(ValueConversions.class, "convertPrimitive", Wrapper.class, Wrapper.class));
-
-        access.registerReachabilityHandler(MethodHandleFeature::registerValueConversionIgnoreForReflection,
-                        ReflectionUtil.lookupMethod(ValueConversions.class, "ignore"));
+        eagerlyInitializeValueConversionsCaches();
 
         access.registerClassInitializerReachabilityHandler(MethodHandleFeature::registerDelegatingMHFunctionsForReflection,
                         access.findClassByName("java.lang.invoke.DelegatingMethodHandle"));
@@ -278,33 +268,33 @@ public class MethodHandleFeature implements InternalFeature {
         RuntimeReflection.register(ReflectionUtil.lookupMethod(invokersClazz, "directVarHandleTarget", access.findClassByName("java.lang.invoke.VarHandle")));
     }
 
-    private static void registerValueConversionBoxFunctionsForReflection(DuringAnalysisAccess access) {
-        for (Wrapper type : Wrapper.values()) {
-            if (type.primitiveType().isPrimitive() && type != Wrapper.VOID) {
-                RuntimeReflection.register(ReflectionUtil.lookupMethod(ValueConversions.class, "box" + type.wrapperSimpleName(), type.primitiveType()));
-            }
-        }
-    }
+    /**
+     * Eagerly initialize method handle caches in {@link ValueConversions} so that 1) we avoid
+     * reflection registration for conversion methods, and 2) the static analysis already sees a
+     * consistent snapshot that does not change after analysis when the JDK needs more conversions.
+     */
+    private static void eagerlyInitializeValueConversionsCaches() {
+        ValueConversions.ignore();
 
-    private static void registerValueConversionUnboxFunctionsForReflection(DuringAnalysisAccess access) {
-        for (Wrapper type : Wrapper.values()) {
-            if (type.primitiveType().isPrimitive() && type != Wrapper.VOID) {
-                RuntimeReflection.register(ReflectionUtil.lookupMethod(ValueConversions.class, "unbox" + type.wrapperSimpleName(), type.wrapperType()));
-                RuntimeReflection.register(ReflectionUtil.lookupMethod(ValueConversions.class, "unbox" + type.wrapperSimpleName(), Object.class, boolean.class));
-            }
-        }
-    }
-
-    private static void registerValueConversionConvertFunctionsForReflection(DuringAnalysisAccess access) {
         for (Wrapper src : Wrapper.values()) {
-            for (Wrapper dest : Wrapper.values()) {
-                if (src != dest && src.primitiveType().isPrimitive() && src != Wrapper.VOID && dest.primitiveType().isPrimitive() && dest != Wrapper.VOID) {
-                    RuntimeReflection.register(ReflectionUtil.lookupMethod(ValueConversions.class, valueConverterName(src, dest), src.primitiveType()));
+            if (src != Wrapper.VOID && src.primitiveType().isPrimitive()) {
+                ValueConversions.boxExact(src);
+
+                ValueConversions.unboxExact(src, false);
+                ValueConversions.unboxExact(src, true);
+                ValueConversions.unboxWiden(src);
+                ValueConversions.unboxCast(src);
+            }
+
+            for (Wrapper dst : Wrapper.values()) {
+                if (src != Wrapper.VOID && dst != Wrapper.VOID && (src == dst || (src.primitiveType().isPrimitive() && dst.primitiveType().isPrimitive()))) {
+                    ValueConversions.convertPrimitive(src, dst);
                 }
             }
         }
     }
 
+<<<<<<< HEAD
     private static String valueConverterName(Wrapper src, Wrapper dest) {
         String srcType = src.primitiveSimpleName();
         String destType = dest.primitiveSimpleName();
@@ -316,6 +306,8 @@ public class MethodHandleFeature implements InternalFeature {
         RuntimeReflection.register(ReflectionUtil.lookupMethod(ValueConversions.class, "ignore", Object.class));
     }
 
+=======
+>>>>>>> fb9b6c06c88 (Eagerly initialize caches in ValueConversions)
     private static void registerDelegatingMHFunctionsForReflection(DuringAnalysisAccess access) {
         Class<?> delegatingMHClazz = access.findClassByName("java.lang.invoke.DelegatingMethodHandle");
         RuntimeReflection.register(ReflectionUtil.lookupMethod(delegatingMHClazz, "getTarget"));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -80,7 +80,6 @@ import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.svm.core.hub.ClassForNameSupport;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.reflect.SubstrateAccessor;
-import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.ConditionalConfigurationRegistry;
 import com.oracle.svm.hosted.FeatureImpl.BeforeAnalysisAccessImpl;
@@ -152,7 +151,15 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
         this.analysisAccess = beforeAnalysisAccess;
     }
 
+<<<<<<< HEAD
     private void register(Consumer<AnalysisUniverse> registrationCallback) {
+=======
+    private void runConditionalInAnalysisTask(ConfigurationCondition condition, Consumer<ConfigurationCondition> task) {
+        if (sealed) {
+            throw new UnsupportedFeatureException("Too late to add classes, methods, and fields for reflective access. Registration must happen in a Feature before the analysis has finished.");
+        }
+
+>>>>>>> fb9b6c06c88 (Eagerly initialize caches in ValueConversions)
         if (universe != null) {
             registrationCallback.accept(universe);
         } else {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -151,15 +151,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
         this.analysisAccess = beforeAnalysisAccess;
     }
 
-<<<<<<< HEAD
     private void register(Consumer<AnalysisUniverse> registrationCallback) {
-=======
-    private void runConditionalInAnalysisTask(ConfigurationCondition condition, Consumer<ConfigurationCondition> task) {
-        if (sealed) {
-            throw new UnsupportedFeatureException("Too late to add classes, methods, and fields for reflective access. Registration must happen in a Feature before the analysis has finished.");
-        }
-
->>>>>>> fb9b6c06c88 (Eagerly initialize caches in ValueConversions)
         if (universe != null) {
             registrationCallback.accept(universe);
         } else {
@@ -509,7 +501,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     private void checkNotSealed() {
         if (sealed) {
-            throw UserError.abort("Too late to add classes, methods, and fields for reflective access. Registration must happen in a Feature before the analysis has finished.");
+            throw new UnsupportedFeatureException("Too late to add classes, methods, and fields for reflective access. Registration must happen in a Feature before the analysis has finished.");
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -994,11 +994,15 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     @Override
     public void registerHeapDynamicHub(Object object, ScanReason reason) {
-        assert !sealed;
         DynamicHub hub = (DynamicHub) object;
         Class<?> javaClass = hub.getHostedJavaClass();
-        if (heapDynamicHubs.add(hub) && !SubstitutionReflectivityFilter.shouldExclude(javaClass, metaAccess, universe)) {
-            registerTypesForClass(metaAccess.lookupJavaType(javaClass), javaClass);
+        if (heapDynamicHubs.add(hub)) {
+            if (sealed) {
+                throw new UnsupportedFeatureException("Registering new class for reflection when the image heap is already sealed: " + javaClass);
+            }
+            if (!SubstitutionReflectivityFilter.shouldExclude(javaClass, metaAccess, universe)) {
+                registerTypesForClass(metaAccess.lookupJavaType(javaClass), javaClass);
+            }
         }
     }
 
@@ -1010,24 +1014,32 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
     @Override
     public void registerHeapReflectionField(Field reflectField, ScanReason reason) {
-        assert !sealed;
         AnalysisField analysisField = metaAccess.lookupJavaField(reflectField);
-        if (heapFields.put(analysisField, reflectField) == null && !SubstitutionReflectivityFilter.shouldExclude(reflectField, metaAccess, universe)) {
-            registerTypesForField(analysisField, reflectField, false);
-            if (analysisField.getDeclaringClass().isAnnotation()) {
-                processAnnotationField(reflectField);
+        if (heapFields.put(analysisField, reflectField) == null) {
+            if (sealed) {
+                throw new UnsupportedFeatureException("Registering new field for reflection when the image heap is already sealed: " + reflectField);
+            }
+            if (!SubstitutionReflectivityFilter.shouldExclude(reflectField, metaAccess, universe)) {
+                registerTypesForField(analysisField, reflectField, false);
+                if (analysisField.getDeclaringClass().isAnnotation()) {
+                    processAnnotationField(reflectField);
+                }
             }
         }
     }
 
     @Override
     public void registerHeapReflectionExecutable(Executable reflectExecutable, ScanReason reason) {
-        assert !sealed;
         AnalysisMethod analysisMethod = metaAccess.lookupJavaMethod(reflectExecutable);
-        if (heapMethods.put(analysisMethod, reflectExecutable) == null && !SubstitutionReflectivityFilter.shouldExclude(reflectExecutable, metaAccess, universe)) {
-            registerTypesForMethod(analysisMethod, reflectExecutable);
-            if (reflectExecutable instanceof Method && reflectExecutable.getDeclaringClass().isAnnotation()) {
-                processAnnotationMethod(false, (Method) reflectExecutable);
+        if (heapMethods.put(analysisMethod, reflectExecutable) == null) {
+            if (sealed) {
+                throw new UnsupportedFeatureException("Registering new method for reflection when the image heap is already sealed: " + reflectExecutable);
+            }
+            if (!SubstitutionReflectivityFilter.shouldExclude(reflectExecutable, metaAccess, universe)) {
+                registerTypesForMethod(analysisMethod, reflectExecutable);
+                if (reflectExecutable instanceof Method && reflectExecutable.getDeclaringClass().isAnnotation()) {
+                    processAnnotationMethod(false, (Method) reflectExecutable);
+                }
             }
         }
     }

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/debug/TraceCompilationListener.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/debug/TraceCompilationListener.java
@@ -85,7 +85,7 @@ public final class TraceCompilationListener extends AbstractGraalTruffleRuntimeL
     private static final String QUEUED_FORMAT   = "opt queued " + TARGET_FORMAT + "|" + TIER_FORMAT + "|" + COUNT_THRESHOLD_FORMAT + "|" + QUEUE_FORMAT + "|UTC %s|Src %s";
     private static final String UNQUEUED_FORMAT = "opt unque. " + TARGET_FORMAT + "|" + TIER_FORMAT + "|" + COUNT_THRESHOLD_FORMAT + "|" + QUEUE_FORMAT + "|UTC %s|Src %s|Reason %s";
     private static final String START_FORMAT    = "opt start  " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Priority %9d|Rate %.6f|"         + QUEUE_FORMAT + "|UTC %s|Src %s";
-    private static final String DONE_FORMAT     = "opt done   " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|AST %4d|Inlined %3dY %3dN|IR %6d/%6d|CodeSize %7d|Addr %7s|UTC %s|Src %s";
+    private static final String DONE_FORMAT     = "opt done   " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|AST %4d|Inlined %3dY %3dN|IR %6d/%6d|CodeSize %7d|Addr 0x%012x|UTC %s|Src %s";
     private static final String FAILED_FORMAT   = "opt failed " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|Reason: %s|UTC %s|Src %s";
     private static final String INV_FORMAT      = "opt inval. " + TARGET_FORMAT + "                                                                                                                |UTC %s|Src %s|Reason %s";
     private static final String DEOPT_FORMAT    = "opt deopt  " + TARGET_FORMAT + "|                                                                                                               |UTC %s|Src %s";
@@ -244,7 +244,7 @@ public final class TraceCompilationListener extends AbstractGraalTruffleRuntimeL
                         compilation.nodeCountPartialEval,
                         graph == null ? 0 : graph.getNodeCount(),
                         result == null ? 0 : result.getTargetCodeSize(),
-                        "0x" + Long.toHexString(target.getCodeAddress()),
+                        target.getCodeAddress(),
                         TIME_FORMATTER.format(ZonedDateTime.now()),
                         formatSourceSection(safeSourceSection(target))));
         currentCompilation.remove();


### PR DESCRIPTION
8th batch of https://github.com/graalvm/graalvm-community-jdk21u/issues/37

Backports:
* https://github.com/oracle/graal/pull/9579
* https://github.com/oracle/graal/pull/9553
* https://github.com/oracle/graal/commit/27c16d50bffedab6b24ab4784eec9407342e3dcd from https://github.com/oracle/graal/pull/9012
* https://github.com/oracle/graal/pull/9583
* https://github.com/oracle/graal/pull/9572

  Conflict 
  
  ``` diff
  diff --cc substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
  index a5e62695a6b,ddacb66b38a..00000000000
  --- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
  +++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
  @@@ -1010,12 -993,16 +1014,23 @@@ public class ReflectionDataBuilder exte
    
        @Override
        public void registerHeapReflectionField(Field reflectField, ScanReason reason) {
  -         assert !sealed;
            AnalysisField analysisField = metaAccess.lookupJavaField(reflectField);
  ++<<<<<<< HEAD
   +        if (heapFields.put(analysisField, reflectField) == null && !SubstitutionReflectivityFilter.shouldExclude(reflectField, metaAccess, universe)) {
   +            registerTypesForField(analysisField, reflectField, false);
   +            if (analysisField.getDeclaringClass().isAnnotation()) {
   +                processAnnotationField(reflectField);
  ++=======
  +         if (heapFields.put(analysisField, reflectField) == null) {
  +             if (sealed) {
  +                 throw new UnsupportedFeatureException("Registering new field for reflection when the image heap is already sealed: " + reflectField);
  +             }
  +             if (!SubstitutionReflectivityFilter.shouldExclude(reflectField, metaAccess, universe)) {
  +                 registerTypesForField(analysisField, reflectField);
  +                 if (analysisField.getDeclaringClass().isAnnotation()) {
  +                     processAnnotationField(reflectField);
  +                 }
  ++>>>>>>> d16da5538e2 (Reset Provider.Service.constructorCache field)
                }
            }
        }
  
  ```

  resolved by accepting both changes a) the addition of `false` as the last parameter of the `registerTypesForField` call, and b) the sealed case handling.

* https://github.com/oracle/graal/commit/8128528b8011ca4aa2764bc5e1bbc8d52306372e from https://github.com/oracle/graal/pull/9515
* "18085cd131a [GR-56101] Backport reachability-metadata.json parser"

  Skipped as changes are already backported with https://github.com/graalvm/graalvm-community-jdk21u/pull/23"

Other changes with no upstream PRs to associate with:

* [GR-55494] Update labsjdk to 23.1-b47
* [GR-53665] SubprocessTest improvements
* [GR-55494] Update labsjdk to 23.1-b48

Except where noted, the backports are clean, there were no conflicts.