### PR TITLE
[Backport] [GR-58292] Add option to disable substitutions

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -411,6 +411,11 @@ public class SubstrateOptions {
     @Option(help = "Verify naming conventions during image construction.")//
     public static final HostedOptionKey<Boolean> VerifyNamingConventions = new HostedOptionKey<>(false);
 
+    @Option(help = "Disable the substitutions matched by the option value. " +
+                    "A value can be a fully qualified method name with parameter list, a fully qualified method name without parameter list, or a fully qualified type name. " +
+                    "When multiple methods match a value, then all matching substitutions are disabled.")//
+    public static final HostedOptionKey<LocatableMultiOptionValue.Strings> DisableSubstitution = new HostedOptionKey<>(LocatableMultiOptionValue.Strings.build());
+
     @Option(help = "Enable support for threads and and thread-local variables (disable for single-threaded implementation)")//
     public static final HostedOptionKey<Boolean> MultiThreaded = new HostedOptionKey<>(true);
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -106,6 +107,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
     private final Map<ResolvedJavaMethod, ResolvedJavaMethod> polymorphicMethodSubstitutions;
     private final Map<ResolvedJavaField, ResolvedJavaField> fieldSubstitutions;
     private ClassInitializationSupport classInitializationSupport;
+    private final Set<String> disabledSubstitutions;
 
     public AnnotationSubstitutionProcessor(ImageClassLoader imageClassLoader, MetaAccessProvider metaAccess, ClassInitializationSupport classInitializationSupport) {
         this.imageClassLoader = imageClassLoader;
@@ -117,6 +119,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
         methodSubstitutions = new ConcurrentHashMap<>();
         polymorphicMethodSubstitutions = new HashMap<>();
         fieldSubstitutions = new ConcurrentHashMap<>();
+        disabledSubstitutions = Set.copyOf(SubstrateOptions.DisableSubstitution.getValue().values());
     }
 
     public void registerFieldValueTransformer(Field reflectionField, FieldValueTransformer transformer) {
@@ -459,6 +462,18 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
         if (original == null) {
             /* Optional target that is not present, so nothing to do. */
             return;
+        }
+
+        if (!disabledSubstitutions.isEmpty()) {
+            /*
+             * Substitutions can be disabled on the command line. The three formats to match are
+             * specified in the help text of the option DisableSubstitution.
+             */
+            if (disabledSubstitutions.contains(annotated.format("%H")) ||
+                            disabledSubstitutions.contains(annotated.format("%H.%n")) ||
+                            disabledSubstitutions.contains(annotated.format("%H.%n(%P)"))) {
+                return;
+            }
         }
 
         if (deleteAnnotation != null) {


### PR DESCRIPTION
Backport Add option to disable substitutions
Cherry picked from commit https://github.com/oracle/graal/pull/9743/commits/65e51884595a88cfb9a8ba6d0d9dc81bed6b3c44

Resolved conflict by keeping local changes and adding only what was added in the commit to the source and changed `AccumulatingLocatableMultiOptionValue` to `LocatableMultiOptionValue` as in upstream `LocatableMultiOptionValue` was renamed to `AccumulatingLocatableMultiOptionValue`

This is part of https://github.com/graalvm/graalvm-community-jdk21u/issues/64