### PR TITLE
[Backport] Flip a bit in test input to avoid unspecified NaN behavior in bitcode tests.

### DIFF
--- a/sulong/tests/com.oracle.truffle.llvm.tests.llirtestgen.native/prelude.c
+++ b/sulong/tests/com.oracle.truffle.llvm.tests.llirtestgen.native/prelude.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -76,7 +76,8 @@ int main(void) {
     print_input(input);
     run(input, input + 32, output);
 
-    fill(input, output, 0xffffffffffffffffl, 0);
+    // not 0xff...f to avoid NaN, otherwise the float test results are unspecified
+    fill(input, output, 0xfefffffffeffffffl, 0);
     print_input(input);
     run(input, input + 32, output);
 
@@ -88,7 +89,8 @@ int main(void) {
     print_input(input);
     run(input, input + 32, output);
 
-    fill(input, output, 0xffffffffffffffffl, -0x0101010101010101l);
+    // not 0xff...f to avoid NaN, otherwise the float test results are unspecified
+    fill(input, output, 0xfefffffffeffffffl, -0x0101010101010101l);
     print_input(input);
     run(input, input + 32, output);
 


### PR DESCRIPTION
Partial backport of https://github.com/oracle/graal/pull/7642 (includes only https://github.com/oracle/graal/commit/3590395d5a2fad848f5305fb606b6b9a040e4cf0)

~Draft until test runs ok.~

Closes: #67 

(cherry picked from commit 3590395d5a2fad848f5305fb606b6b9a040e4cf0)