### PR TITLE
[Backport][GR-59499] Fix System.getProperties() when called from virtual thread.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.java
@@ -30,7 +30,6 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 
 import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.StackValue;
 import org.graalvm.nativeimage.c.struct.SizeOf;
 import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CIntPointer;
@@ -39,6 +38,7 @@ import org.graalvm.nativeimage.c.type.CTypeConversion.CCharPointerHolder;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.impl.UnmanagedMemorySupport;
 import org.graalvm.nativeimage.UnmanagedMemory;
+import org.graalvm.word.Pointer;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.SignedWord;
 import org.graalvm.word.UnsignedWord;
@@ -356,15 +356,17 @@ public class PosixUtils {
             bufSize = 1024;
         }
 
-        /* Retrieve the username and copy it to a String object. */
-        CCharPointer pwBuf = ImageSingletons.lookup(UnmanagedMemorySupport.class).malloc(WordFactory.unsigned(bufSize));
-        if (pwBuf.isNull()) {
+        /* Does not use StackValue because it is not safe to use in virtual threads. */
+        UnsignedWord allocSize = WordFactory.unsigned(SizeOf.get(passwdPointer.class) + SizeOf.get(passwd.class) + bufSize);
+        Pointer alloc = ImageSingletons.lookup(UnmanagedMemorySupport.class).malloc(allocSize);
+        if (alloc.isNull()) {
             return null;
         }
 
         try {
-            passwd pwent = StackValue.get(passwd.class);
-            passwdPointer p = StackValue.get(passwdPointer.class);
+            passwdPointer p = (passwdPointer) alloc;
+            passwd pwent = (passwd) ((Pointer) p).add(SizeOf.get(passwdPointer.class));
+            CCharPointer pwBuf = (CCharPointer) ((Pointer) pwent).add(SizeOf.get(passwd.class));
             int code = Pwd.getpwuid_r(uid, pwent, pwBuf, WordFactory.unsigned(bufSize), p);
             if (code != 0) {
                 return null;
@@ -382,7 +384,7 @@ public class PosixUtils {
 
             return CTypeConversion.toJavaString(pwName);
         } finally {
-            UnmanagedMemory.free(pwBuf);
+            UnmanagedMemory.free(alloc);
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Pwd.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Pwd.java
@@ -30,7 +30,6 @@ import org.graalvm.nativeimage.c.struct.CField;
 import org.graalvm.nativeimage.c.struct.CPointerTo;
 import org.graalvm.nativeimage.c.struct.CStruct;
 import org.graalvm.nativeimage.c.type.CCharPointer;
-import org.graalvm.word.Pointer;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.UnsignedWord;
 
@@ -52,7 +51,7 @@ public class Pwd {
     }
 
     @CPointerTo(passwd.class)
-    public interface passwdPointer extends Pointer {
+    public interface passwdPointer extends PointerBase {
         passwd read();
     }
 


### PR DESCRIPTION
This PR backports the [GR-59499](https://github.com/oracle/graal/issues/9939) as part of the https://github.com/graalvm/graalvm-community-jdk21u/issues/66#top effort.

Changes:
- cherry-picked the https://github.com/oracle/graal/commit/015a8f7fdd5594b7bfbe5de266c7bb56e36dd9de fix
- resolved a merge conflict in PosixUtils.getUserNameOrDir(..) caused by the missing [native memory tracker](https://github.com/oracle/graal/commit/adab8a8a4bace12e7455aa79b77f21c1e85623da) in graalvm-jdk21u
<details>
<summary>merge conflict resolution details</summary>

Here is the diff: the original change (left) and a change applied to graalvm-jdk21u (right)
```diff
commit aade614612ab24d9642a5d3bbfd40a3c437f0e5b                                                    |    commit ecbfc5e7ead7915ca403610bf011bb566ece46f0 (HEAD -> GR-59499)
Author: Peter Hofer <peter.hofer@oracle.com>                                                       |    Author: Boris Ulasevich <Boris.Ulasevich@bell-sw.com>
Date:   Mon Nov 18 17:54:39 2024 +0100                                                             |    Date:   Thu May 22 06:08:47 2025 -0300
                                                                                                   
    Fix System.getProperties() when called from virtual thread.                                    |        [GR-59499] Fix System.getProperties() when called from virtual thread.
                                                                                                    
diff --git a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.        diff --git a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.
index 45433f961d3..a477be5230f 100644                                                              |    index 61f4bc9adc3..92099641928 100644
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.java           --- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.java           +++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.java
@@ -30,7 +30,7 @@ import static com.oracle.svm.core.posix.headers.Unistd._SC_GETPW_R_SIZE_MAX;     |    @@ -30,7 +30,6 @@ import java.io.FileDescriptor;
 import java.io.FileDescriptor;                                                                    |     import java.io.IOException;

 import org.graalvm.nativeimage.Platform;                                                                import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.StackValue;                                                             -import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.struct.SizeOf;                                                   |     import org.graalvm.nativeimage.c.struct.SizeOf;
 import org.graalvm.nativeimage.c.type.CCharPointer;                                                     import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CIntPointer;                                                      import org.graalvm.nativeimage.c.type.CIntPointer;
 import org.graalvm.nativeimage.c.type.CTypeConversion;                                            |    @@ -39,6 +38,7 @@ import org.graalvm.nativeimage.c.type.CTypeConversion.CCharPointerHolder;
                                                                                                   |     import org.graalvm.nativeimage.ImageSingletons;
                                                                                                   |     import org.graalvm.nativeimage.impl.UnmanagedMemorySupport;
                                                                                                   |     import org.graalvm.nativeimage.UnmanagedMemory;
                                                                                                   |    +import org.graalvm.word.Pointer;
                                                                                                   |     import org.graalvm.word.PointerBase;
                                                                                                   |     import org.graalvm.word.SignedWord;
                                                                                                   |     import org.graalvm.word.UnsignedWord;
@@ -335,15 +335,17 @@ public class PosixUtils {                                                         @@ -356,15 +356,17 @@ public class PosixUtils {
             bufSize = 1024;                                                                                         bufSize = 1024;
         }                                                                                                       }

-        /* Retrieve the username and copy it to a String object. */                                    -        /* Retrieve the username and copy it to a String object. */
-        CCharPointer pwBuf = NullableNativeMemory.malloc(WordFactory.unsigned(bufSize), NmtCate   |    -        CCharPointer pwBuf = ImageSingletons.lookup(UnmanagedMemorySupport.class).malloc(WordFa
-        if (pwBuf.isNull()) {                                                                          -        if (pwBuf.isNull()) {
+        /* Does not use StackValue because it is not safe to use in virtual threads. */                +        /* Does not use StackValue because it is not safe to use in virtual threads. */
+        UnsignedWord allocSize = WordFactory.unsigned(SizeOf.get(passwdPointer.class) + SizeOf.        +        UnsignedWord allocSize = WordFactory.unsigned(SizeOf.get(passwdPointer.class) + SizeOf.
+        Pointer alloc = NullableNativeMemory.malloc(allocSize, NmtCategory.Internal);             |    +        Pointer alloc = ImageSingletons.lookup(UnmanagedMemorySupport.class).malloc(allocSize);
+        if (alloc.isNull()) {                                                                          +        if (alloc.isNull()) {
             return null;                                                                                            return null;
         }                                                                                                       }

         try {                                                                                                   try {
-            passwd pwent = StackValue.get(passwd.class);                                               -            passwd pwent = StackValue.get(passwd.class);
-            passwdPointer p = StackValue.get(passwdPointer.class);                                     -            passwdPointer p = StackValue.get(passwdPointer.class);
+            passwdPointer p = (passwdPointer) alloc;                                                   +            passwdPointer p = (passwdPointer) alloc;
+            passwd pwent = (passwd) ((Pointer) p).add(SizeOf.get(passwdPointer.class));                +            passwd pwent = (passwd) ((Pointer) p).add(SizeOf.get(passwdPointer.class));
+            CCharPointer pwBuf = (CCharPointer) ((Pointer) pwent).add(SizeOf.get(passwd.class))        +            CCharPointer pwBuf = (CCharPointer) ((Pointer) pwent).add(SizeOf.get(passwd.class))
             int code = Pwd.getpwuid_r(uid, pwent, pwBuf, WordFactory.unsigned(bufSize), p);                         int code = Pwd.getpwuid_r(uid, pwent, pwBuf, WordFactory.unsigned(bufSize), p);
             if (code != 0) {                                                                                        if (code != 0) {
                 return null;                                                                                            return null;
@@ -361,7 +363,7 @@ public class PosixUtils {                                                           @@ -382,7 +384,7 @@ public class PosixUtils {

             return CTypeConversion.toJavaString(pwName);                                                            return CTypeConversion.toJavaString(pwName);
         } finally {                                                                                             } finally {
-            NullableNativeMemory.free(pwBuf);                                                     |    -            UnmanagedMemory.free(pwBuf);
+            NullableNativeMemory.free(alloc);                                                     |    +            UnmanagedMemory.free(alloc);
         }                                                                                                       }
     }                                                                                                       }
 }                                                                                                       }
```
</details>

Impact:
- Fixes IllegalThreadStateException thrown by native image, as reported by a user

Verification:
- tested using the test case mentioned in [GR-59499 issue](https://github.com/oracle/graal/issues/9939) (fails before, passes after)
