### PR TITLE
[Backport][GR-62340] Use correct acquisition count in acquireOnOOME.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
@@ -557,7 +557,7 @@ abstract class JavaMonitorQueuedSynchronizer {
 
         // see AbstractQueuedLongSynchronizer.ConditionObject.newConditionNode()
         private ConditionNode newConditionNode() {
-            long savedState;
+            long savedAcquisitions;
             if (tryInitializeHead() != null) {
                 try {
                     return allocateConditionNode();
@@ -565,11 +565,11 @@ abstract class JavaMonitorQueuedSynchronizer {
                 }
             }
             // fall through if encountered OutOfMemoryError
-            if (!isHeldExclusively() || !release(savedState = getState())) {
+            if (!isHeldExclusively() || !release(savedAcquisitions = getAcquisitions())) {
                 throw new IllegalMonitorStateException();
             }
             U.park(false, OOME_COND_WAIT_DELAY);
-            acquireOnOOME(savedState);
+            acquireOnOOME(savedAcquisitions);
             return null;
         }
 


### PR DESCRIPTION
This PR backports the [GR-62340](https://github.com/oracle/graal/pull/10722) as part of the https://github.com/graalvm/graalvm-community-jdk21u/issues/66 effort.

Changes:
- cherry-picked the https://github.com/oracle/graal/commit/07421a71ab0a1a628cfbe42cfff0cf690f640317 fix
- (clean backport)

Impact
- Fixes under- or over-re-acquisition of the monitor in SubstrateVM’s fallback path after an OutOfMemoryError