### PR TITLE
[Backport][GR-63455] Remove pointless parallel stream processing for classpath entries.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageClassLoaderSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageClassLoaderSupport.java
@@ -625,7 +625,7 @@ public class NativeImageClassLoaderSupport {
                     initModule(moduleReference);
                 }
 
-                classpath().parallelStream().forEach(this::loadClassesFromPath);
+                classpath().forEach(this::loadClassesFromPath);
             } finally {
                 scheduledExecutor.shutdown();
             }


### PR DESCRIPTION
Since we already execute all calls to
NativeImageClassLoaderSupport.LoadClassHandler#handleClassFileName via the ForkJoinPool.commonPool(), the use of parallelStream() here does not further increase parallel execution and can be replaced with a simple forEach without increasing class initialization time.

Additionally, avoiding parallelStream() fixes a deadlock that was observable when only one CPU core is available (parallel streams also use the commonPool() and this can lead to a deadlock with our own use on single core systems).

(cherry picked from commit 8ecf1132b617721d9bf224191430fb31786b5f5f)

Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/76