### PR TITLE
[Backport][GR-63528] Fix for ThreadLookup.matchesThread().

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/thread/PosixVMThreads.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/thread/PosixVMThreads.java
@@ -147,7 +147,7 @@ public final class PosixVMThreads extends VMThreads {
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         public boolean matchesThread(IsolateThread thread, ComparableWord identifier) {
-            return VMThreads.OSThreadHandleTL.get(thread).notEqual(identifier);
+            return VMThreads.OSThreadHandleTL.get(thread).equal(identifier);
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
@@ -613,8 +613,9 @@ public abstract class VMThreads {
             THREAD_MUTEX.lockNoTransitionUnspecifiedOwner();
         }
         try {
-            IsolateThread thread;
-            for (thread = firstThreadUnsafe(); thread.isNonNull() && threadLookup.matchesThread(thread, identifier); thread = nextThread(thread)) {
+            IsolateThread thread = firstThreadUnsafe();
+            while (thread.isNonNull() && !threadLookup.matchesThread(thread, identifier)) {
+                thread = nextThread(thread);
             }
             return thread;
         } finally {
@@ -1096,7 +1097,7 @@ public abstract class VMThreads {
 
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         public boolean matchesThread(IsolateThread thread, ComparableWord identifier) {
-            return OSThreadIdTL.get(thread).notEqual(identifier);
+            return OSThreadIdTL.get(thread).equal(identifier);
         }
     }
 }


### PR DESCRIPTION
**This PR backports:**
- part of https://github.com/oracle/graal/pull/10935

Fix for ThreadLookup.matchesThread().

Cherry picked from commit 1e7b5abc03784b0ac482550e0d320480e4b5d2e4

Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/71