### PR TITLE
Backport] [GR-49635] [GR-59954] Update ClassLoaderValue maps to properly support modular service loading

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -345,6 +345,24 @@ suite = {
       "workingSets" : "Graal,HotSpot,Test",
     },
 
+    # javaCompliance: 23+ effectively disables these tests when running graalvm-jdk21
+    "org.graalvm.compiler.hotspot.jdk23.test" : {
+      "testProject" : True,
+      "subDir" : "src",
+      "sourceDirs" : ["src"],
+      "dependencies" : [
+        "jdk.internal.vm.compiler.test",
+      ],
+      "requiresConcealed" : {
+        "java.base" : [
+        ],
+      },
+      "checkstyle": "jdk.internal.vm.compiler",
+      "javaCompliance" : "23+",
+      "javaPreviewNeeded": "23+",
+      "workingSets" : "Graal,HotSpot,Test",
+    },
+
     "org.graalvm.compiler.virtual.bench" : {
       "subDir" : "src",
       "sourceDirs" : ["src"],

--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -345,24 +345,6 @@ suite = {
       "workingSets" : "Graal,HotSpot,Test",
     },
 
-    # javaCompliance: 23+ effectively disables these tests when running graalvm-jdk21
-    "org.graalvm.compiler.hotspot.jdk23.test" : {
-      "testProject" : True,
-      "subDir" : "src",
-      "sourceDirs" : ["src"],
-      "dependencies" : [
-        "jdk.internal.vm.compiler.test",
-      ],
-      "requiresConcealed" : {
-        "java.base" : [
-        ],
-      },
-      "checkstyle": "jdk.internal.vm.compiler",
-      "javaCompliance" : "23+",
-      "javaPreviewNeeded": "23+",
-      "workingSets" : "Graal,HotSpot,Test",
-    },
-
     "org.graalvm.compiler.virtual.bench" : {
       "subDir" : "src",
       "sourceDirs" : ["src"],

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/java/BytecodeParser.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/java/BytecodeParser.java
@@ -2711,7 +2711,7 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
 
         ValueNode realReturnVal = processReturnValue(returnVal, returnKind);
 
-        frameState.setRethrowException(false);
+        assert !frameState.rethrowException() : frameState;
         frameState.clearStack();
         beforeReturn(realReturnVal, returnKind);
         if (parent == null) {
@@ -2950,10 +2950,6 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
                     bci = ((ExceptionDispatchBlock) targetBlock).deoptBci;
                 }
                 FrameStateBuilder newState = target.state.copy();
-                // Perform the same logic as is done in processBlock
-                if (targetBlock != blockMap.getUnwindBlock() && !(targetBlock instanceof ExceptionDispatchBlock)) {
-                    newState.setRethrowException(false);
-                }
                 clearNonLiveLocalsAtLoopExitCreation(targetBlock, newState);
 
                 for (BciBlock loop : exitLoops) {
@@ -2991,9 +2987,8 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
         if (targetBlock != blockMap.getUnwindBlock()) {
             return new Target(target, state);
         }
-        FrameStateBuilder newState = state;
-        newState = newState.copy();
-        newState.setRethrowException(false);
+        assert !state.rethrowException() : state;
+        FrameStateBuilder newState = state.copy();
         if (!method.isSynchronized()) {
             return new Target(target, newState);
         }
@@ -3069,11 +3064,24 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
     }
 
     @SuppressWarnings("try")
-    private FixedNode createTarget(BciBlock block, FrameStateBuilder state, boolean canReuseInstruction, boolean canReuseState) {
-        assert block != null && state != null;
-        assert !block.isExceptionEntry() || state.stackSize() == 1;
+    private FixedNode createTarget(BciBlock block, FrameStateBuilder initialState, boolean canReuseInstruction, boolean canReuseState) {
+        assert block != null;
+        assert initialState != null;
+        assert !block.isExceptionEntry() || initialState.stackSize() == 1;
 
-        try (DebugCloseable context = openNodeContext(state, block.startBci)) {
+        try (DebugCloseable context = openNodeContext(initialState, block.startBci)) {
+
+            FrameStateBuilder state = initialState;
+            if (initialState.rethrowException() && (block == blockMap.getUnwindBlock() || !(block instanceof ExceptionDispatchBlock))) {
+                /*
+                 * Exceptions are only rethrown if deopts happen during the dispatch process. The
+                 * unwind block is the only ExceptionDispatchBlock where rethrowException must be
+                 * false.
+                 */
+                state = initialState.copy();
+                state.setRethrowException(false);
+            }
+
             if (getFirstInstruction(block) == null) {
                 /*
                  * This is the first time we see this block as a branch target. Create and return a
@@ -3099,7 +3107,7 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
                 Target target = checkUnwind(getFirstInstruction(block), block, state);
                 target = checkLoopExit(target, block);
                 FixedNode result = target.entry;
-                FrameStateBuilder currentEntryState = target.state == state ? (canReuseState ? state : state.copy()) : target.state;
+                FrameStateBuilder currentEntryState = target.state == initialState ? (canReuseState ? initialState : initialState.copy()) : target.state;
                 setEntryState(block, currentEntryState);
                 clearNonLiveLocalsAtTargetCreation(block, currentEntryState);
 
@@ -3118,13 +3126,11 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
                 Target target = checkLoopExit(new Target(loopEnd, state.copy()), block);
                 FixedNode result = target.entry;
                 /*
-                 * It is guaranteed that a loop header cannot be an ExceptionDispatchBlock. By the
-                 * time the backward loop edge is reached, the block will already be processed, and
-                 * its rethrow exception will be set to false.
+                 * It is guaranteed that a loop header cannot be an ExceptionDispatchBlock.
+                 * Therefore, the rethrowException flag of its entry state must be false.
                  */
-                assert !(block instanceof ExceptionDispatchBlock);
-                assert !getEntryState(block).rethrowException();
-                target.state.setRethrowException(false);
+                assert !getEntryState(block).rethrowException() : getEntryState(block);
+                assert !target.state.rethrowException() : target.state;
                 getEntryState(block).merge(loopBegin, target.state);
 
                 debug.log("createTarget %s: merging backward branch to loop header %s, result: %s", block, loopBegin, result);
@@ -3211,10 +3217,6 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
             lastInstr = firstInstruction;
             frameState = getEntryState(block);
             currentBlock = block;
-
-            if (block != blockMap.getUnwindBlock() && !(block instanceof ExceptionDispatchBlock)) {
-                frameState.setRethrowException(false);
-            }
 
             if (firstInstruction instanceof AbstractMergeNode) {
                 setMergeStateAfter(block, firstInstruction);

--- a/compiler/src/org.graalvm.compiler.hotspot.jdk23.test/src/org/graalvm/compiler/hotspot/jdk23/test/SharedExceptionHandlerLoopTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.jdk23.test/src/org/graalvm/compiler/hotspot/jdk23/test/SharedExceptionHandlerLoopTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.hotspot.jdk23.test;
+
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.Label;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+
+import org.junit.Test;
+
+import org.graalvm.compiler.core.test.CustomizedBytecodePatternTest;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+/**
+ * Tests a bytecode pattern where two ExceptionDispatchBlocks - one inside a loop and one outside -
+ * dispatch to the same exception handler. Such a pattern cannot be produced by javac from plain
+ * Java code, but the Kotlin compiler can produce such patterns when compiling coroutines. See
+ * {@link #generateClass} for the Java source code from which the modified bytecode is derived.
+ */
+public class SharedExceptionHandlerLoopTest extends CustomizedBytecodePatternTest {
+
+    @Test
+    public void test() throws ClassNotFoundException {
+        Class<?> testClass = getClass("TestClass");
+        ResolvedJavaMethod method = getResolvedJavaMethod(testClass, "testMethod");
+        compile(method, null);
+
+        /*
+         * Returns o1.toString().
+         */
+        test(method, null, new Object(), new NPEThrower());
+        /*
+         * Returns null because o1.toString() throws an NPE.
+         */
+        test(method, null, new NPEThrower(), new NPEThrower());
+        /*
+         * Exits the loop because o1.toString() throws an IAE, returns null because o2.toString()
+         * throws a NPE.
+         */
+        test(method, null, new IAEThrower(), new NPEThrower());
+        /*
+         * Exits the loop because o1.toString() throws an IAE, returns o2.toString().
+         */
+        test(method, null, new IllegalArgumentException(), new Object());
+    }
+
+    public static class NPEThrower {
+        @Override
+        public String toString() {
+            throw new NullPointerException();
+        }
+    }
+
+    public static class IAEThrower {
+        @Override
+        public String toString() {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Produces bytecode which resembles the following Java code except that both NPE-catches
+     * dispatch to the same handler. The first exception dispatch happens from inside the loop, the
+     * second from outside.
+     *
+     * <pre>
+     * public class TestClass {
+     *     public static Object testMethod(Object o1, Object o2) {
+     *         for (;;) {
+     *             try {
+     *                 return o1.toString();
+     *             } catch (NullPointerException e) {
+     *                 // same NPE handler as below. dispatch block inside loop
+     *                 return null;
+     *             } catch (SecurityException e) {
+     *                 // continue (endless loop)
+     *             } catch (Exception e) {
+     *                 break;
+     *             }
+     *         }
+     *
+     *         try {
+     *             return o2.toString();
+     *         } catch (NullPointerException npe) {
+     *             // same NPE handler as above. dispatch block outside loop
+     *             return null;
+     *         }
+     *     }
+     * }
+     * </pre>
+     */
+    @Override
+    protected byte[] generateClass(String internalClassName) {
+        MethodTypeDesc getMethodTypeDesc = MethodTypeDesc.of(ConstantDescs.CD_Object, ConstantDescs.CD_Object, ConstantDescs.CD_Object);
+
+        ClassDesc thisClass = ClassDesc.of(internalClassName.replace('/', '.'));
+        return ClassFile.of().build(thisClass, classBuilder -> classBuilder
+        // @formatter:off
+                        .withMethod("testMethod", getMethodTypeDesc, ACC_PUBLIC | ACC_STATIC, methodBuilder -> methodBuilder.withCode(codeBuilder -> {
+                            Label start = codeBuilder.newLabel();
+                            Label loopExcEnd = codeBuilder.newLabel();
+                            Label loopNPEHandler = codeBuilder.newLabel();
+                            Label loopIAEHandler = codeBuilder.newLabel();
+                            Label loopEHandler = codeBuilder.newLabel();
+                            Label retLabel = codeBuilder.newLabel();
+
+                            Label afterLoopExcStart = codeBuilder.newLabel();
+                            Label afterLoopExcEnd = codeBuilder.newLabel();
+
+                            codeBuilder
+                                            .labelBinding(start)
+                                            .aload(0)
+                                            .invokevirtual(ConstantDescs.CD_Object, "toString", MethodTypeDesc.of(ConstantDescs.CD_String))
+                                            .labelBinding(loopExcEnd)
+                                            .areturn()
+                                            .labelBinding(loopNPEHandler)
+                                            .exceptionCatch(start, loopExcEnd, loopNPEHandler, cd(NullPointerException.class))
+                                            .astore(2)
+                                            .aconst_null()
+                                            .areturn()
+                                            .labelBinding(loopIAEHandler)
+                                            .exceptionCatch(start, loopExcEnd, loopIAEHandler, cd(IllegalAccessError.class))
+                                            .astore(2)
+                                            .goto_(start)
+                                            .labelBinding(loopEHandler)
+                                            .exceptionCatch(start, loopExcEnd, loopEHandler, ConstantDescs.CD_Exception)
+                                            .astore(2)
+                                            .goto_(retLabel)
+                                            .labelBinding(retLabel)
+                                            .labelBinding(afterLoopExcStart)
+                                            .aload(1)
+                                            .invokevirtual(ConstantDescs.CD_Object, "toString", MethodTypeDesc.of(ConstantDescs.CD_String))
+                                            .labelBinding(afterLoopExcEnd)
+                                            .exceptionCatch(afterLoopExcStart, afterLoopExcEnd, loopNPEHandler, cd(NullPointerException.class))
+                                            .areturn();
+                        })));
+        // @formatter:on
+    }
+
+    public static ClassDesc cd(Class<?> klass) {
+        return klass.describeConstable().orElseThrow();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
@@ -83,7 +83,6 @@ import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.util.ReflectionUtil;
 
 import jdk.internal.loader.ClassLoaderValue;
-import jdk.internal.module.ServicesCatalog;
 
 @TargetClass(java.lang.Object.class)
 @SuppressWarnings("static-method")
@@ -914,24 +913,7 @@ final class ClassLoaderValueMapFieldValueTransformer implements FieldValueTransf
         if (originalValue == null) {
             return null;
         }
-
-        ConcurrentHashMap<?, ?> original = (ConcurrentHashMap<?, ?>) originalValue;
-        List<ClassLoaderValue<?>> clvs = Arrays.asList(
-                        ReflectionUtil.readField(ServicesCatalog.class, "CLV", null),
-                        ReflectionUtil.readField(ModuleLayer.class, "CLV", null));
-
-        var res = new ConcurrentHashMap<>();
-        for (ClassLoaderValue<?> clv : clvs) {
-            if (clv == null) {
-                throw VMError.shouldNotReachHere("Field must not be null. Please check what changed in the JDK.");
-            }
-            var catalog = original.get(clv);
-            if (catalog != null) {
-                res.put(clv, catalog);
-            }
-        }
-
-        return res;
+        return RuntimeClassLoaderValueSupport.instance().getClassLoaderValueMapForLoader((ClassLoader) receiver);
     }
 }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/RuntimeClassLoaderValueSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/RuntimeClassLoaderValueSupport.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import com.oracle.svm.core.BuildPhaseProvider.AfterHostedUniverse;
+import com.oracle.svm.core.feature.AutomaticallyRegisteredImageSingleton;
+import com.oracle.svm.core.heap.UnknownObjectField;
+import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.util.ReflectionUtil;
+import jdk.internal.loader.ClassLoaderValue;
+import jdk.internal.loader.ClassLoaders;
+import jdk.internal.module.ServicesCatalog;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+/**
+ * <p>
+ * Runtime support for {@link ClassLoaderValue} (CLV) mappings in the JDK.
+ * {@link jdk.internal.loader.BootLoader} has a static CLV, whereas every {@link ClassLoader}
+ * instance has its own {@link ClassLoaderValue} map. Most CLV mappings are cleared for runtime,
+ * except for {@link ServicesCatalog} and {@link ModuleLayer} CLV mappings.
+ * </p>
+ * <p>
+ * As these mappings contain {@link ModuleLayer} (and through it, also {@link Module}) references,
+ * it is necessary that we do not capture hosted {@link Module} and {@link ModuleLayer} instances.
+ * Since {@link ModuleLayer} synthesis occurs after analysis, this singleton is only populated after
+ * analysis (hence the {@link UnknownObjectField} annotation). The fields in this singleton are used
+ * inside {@link org.graalvm.nativeimage.hosted.FieldValueTransformer}s for CLV mappings (see
+ * {@link ClassLoaderValueMapFieldValueTransformer}, {@link ModuleLayerCLVTransformer} and
+ * {@link ServicesCatalogCLVTransformer}).
+ * </p>
+ */
+@AutomaticallyRegisteredImageSingleton
+public final class RuntimeClassLoaderValueSupport {
+
+    public static RuntimeClassLoaderValueSupport instance() {
+        return ImageSingletons.lookup(RuntimeClassLoaderValueSupport.class);
+    }
+
+    @UnknownObjectField(availability = AfterHostedUniverse.class) //
+    private ConcurrentHashMap<?, ?> bootLoaderCLV = new ConcurrentHashMap<>();
+
+    @UnknownObjectField(availability = AfterHostedUniverse.class) //
+    private ConcurrentHashMap<ClassLoader, ConcurrentHashMap<?, ?>> classLoaderValueMaps = new ConcurrentHashMap<>();
+
+    @UnknownObjectField(availability = AfterHostedUniverse.class) //
+    ClassLoaderValue<ServicesCatalog> servicesCatalogCLV = new ClassLoaderValue<>();
+
+    @UnknownObjectField(availability = AfterHostedUniverse.class) //
+    ClassLoaderValue<List<ModuleLayer>> moduleLayerCLV = new ClassLoaderValue<>();
+
+    @Platforms(Platform.HOSTED_ONLY.class) //
+    public void update(List<ModuleLayer> runtimeModuleLayers) {
+        for (ModuleLayer runtimeLayer : runtimeModuleLayers) {
+            Set<ClassLoader> loaders = runtimeLayer.modules().stream()
+                            .map(Module::getClassLoader)
+                            .collect(Collectors.toSet());
+            for (ClassLoader loader : loaders) {
+                bindRuntimeModuleLayerToLoader(runtimeLayer, loader);
+                registerServicesCatalog(loader);
+            }
+        }
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class) //
+    private ClassLoader hostedBootLoader;
+
+    @Platforms(Platform.HOSTED_ONLY.class) //
+    ConcurrentHashMap<?, ?> getClassLoaderValueMapForLoader(ClassLoader loader) {
+        if (loader == null) {
+            return bootLoaderCLV;
+        } else {
+            return classLoaderValueMaps.computeIfAbsent(loader, k -> new ConcurrentHashMap<>());
+        }
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    private ClassLoader resolveClassLoader(ClassLoader loaderOrNull) {
+        if (loaderOrNull == null) {
+            if (hostedBootLoader != null) {
+                return hostedBootLoader;
+            }
+            Method method = ReflectionUtil.lookupMethod(ClassLoaders.class, "bootLoader");
+            hostedBootLoader = ReflectionUtil.invokeMethod(method, null);
+            return hostedBootLoader;
+        } else {
+            return loaderOrNull;
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"}) //
+    @Platforms(Platform.HOSTED_ONLY.class) //
+    private void bindRuntimeModuleLayerToLoader(ModuleLayer layer, ClassLoader loaderOrNull) {
+        ClassLoader loader = resolveClassLoader(loaderOrNull);
+
+        /**
+         * Runtime {@link ModuleLayer}s are synthesized and bound to loaders after analysis. This
+         * implementation is identical to {@link java.lang.ModuleLayer.bindToLoader}.
+         */
+        List<ModuleLayer> list = moduleLayerCLV.get(loader);
+        if (list == null) {
+            list = new CopyOnWriteArrayList<>();
+            List<ModuleLayer> previous = moduleLayerCLV.putIfAbsent(loader, list);
+            if (previous != null) {
+                list = previous;
+            }
+        }
+        list.add(layer);
+
+        /*
+         * Register the module layer in the appropriate CLV for the given loader.
+         */
+        var classLoaderValueMap = getClassLoaderValueMapForLoader(loader);
+        ((ConcurrentHashMap) classLoaderValueMap).put(moduleLayerCLV, list);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"}) //
+    @Platforms(Platform.HOSTED_ONLY.class) //
+    private void registerServicesCatalog(ClassLoader loaderOrNull) {
+        ClassLoader loader = resolveClassLoader(loaderOrNull);
+
+        /*
+         * Register the catalog in the ServicesCatalog CLV.
+         */
+        ServicesCatalog servicesCatalog = getHostedServiceCatalogForLoader(loader);
+        if (servicesCatalog == null) {
+            servicesCatalog = ServicesCatalog.create();
+        }
+        servicesCatalogCLV.putIfAbsent(loader, servicesCatalog);
+
+        /*
+         * Register the module layer in the appropriate CLV for the given loader.
+         */
+        var classLoaderValueMap = getClassLoaderValueMapForLoader(loader);
+        ((ConcurrentHashMap) classLoaderValueMap).put(servicesCatalogCLV, servicesCatalog);
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class) //
+    private final Field classLoaderCLVField = ReflectionUtil.lookupField(ClassLoader.class, "classLoaderValueMap");
+
+    @Platforms(Platform.HOSTED_ONLY.class) //
+    private final ClassLoaderValue<ServicesCatalog> hostedServicesCatalogCLV = ReflectionUtil.readField(ServicesCatalog.class, "CLV", null);
+
+    @Platforms(Platform.HOSTED_ONLY.class) //
+    private ServicesCatalog getHostedServiceCatalogForLoader(ClassLoader loader) {
+        try {
+            ConcurrentHashMap<?, ?> hostedLoaderCLV = (ConcurrentHashMap<?, ?>) classLoaderCLVField.get(loader);
+            ServicesCatalog servicesCatalog = (ServicesCatalog) hostedLoaderCLV.get(hostedServicesCatalogCLV);
+            return servicesCatalog;
+        } catch (IllegalAccessException e) {
+            throw VMError.shouldNotReachHere("Failed to query ClassLoader.classLoaderValueMap", e);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_internal_module_ServicesCatalog.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_internal_module_ServicesCatalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,29 +26,22 @@ package com.oracle.svm.core.jdk;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
-import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import jdk.internal.loader.ClassLoaderValue;
+import jdk.internal.module.ServicesCatalog;
 import org.graalvm.nativeimage.hosted.FieldValueTransformer;
 
-import java.util.List;
-
 @SuppressWarnings("unused")
-@TargetClass(value = java.lang.ModuleLayer.class)
-final class Target_java_lang_ModuleLayer {
+@TargetClass(value = ServicesCatalog.class)
+final class Target_jdk_internal_module_ServicesCatalog {
 
-    @Substitute
-    public static ModuleLayer boot() {
-        return RuntimeModuleSupport.instance().getBootLayer();
-    }
-
-    @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Custom, declClass = ModuleLayerCLVTransformer.class, isFinal = true) //
-    static ClassLoaderValue<List<ModuleLayer>> CLV;
+    @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Custom, declClass = ServicesCatalogCLVTransformer.class, isFinal = true) //
+    static ClassLoaderValue<ServicesCatalog> CLV;
 }
 
-final class ModuleLayerCLVTransformer implements FieldValueTransformer {
+final class ServicesCatalogCLVTransformer implements FieldValueTransformer {
     @Override
     public Object transform(Object receiver, Object originalValue) {
-        return originalValue != null ? RuntimeClassLoaderValueSupport.instance().moduleLayerCLV : null;
+        return originalValue != null ? RuntimeClassLoaderValueSupport.instance().servicesCatalogCLV : null;
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ModuleLayerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ModuleLayerFeature.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.svm.hosted;
 
+import static com.oracle.svm.core.util.VMError.shouldNotReachHereAtRuntime;
+
 import java.lang.module.Configuration;
 import java.lang.module.FindException;
 import java.lang.module.ModuleDescriptor;
@@ -67,9 +69,9 @@ import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.jdk.Resources;
 import com.oracle.svm.core.jdk.RuntimeClassLoaderValueSupport;
 import com.oracle.svm.core.jdk.RuntimeModuleSupport;
-import com.oracle.svm.core.util.HostedSubstrateUtil;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.FeatureImpl.AnalysisAccessBase;
+import com.oracle.svm.hosted.ClassLoaderFeature;
 import com.oracle.svm.util.LogUtils;
 import com.oracle.svm.util.ModuleSupport;
 import com.oracle.svm.util.ReflectionUtil;
@@ -436,7 +438,7 @@ public final class ModuleLayerFeature implements InternalFeature {
                 moduleLayerFeatureUtils.patchModuleLayerField(runtimeSyntheticModule, runtimeModuleLayer);
             }
             ServicesCatalog servicesCatalog = synthesizeRuntimeModuleLayerServicesCatalog(nameToModule);
-            patchRuntimeModuleLayer(accessImpl, runtimeModuleLayer, nameToModule, parentLayers, servicesCatalog);
+            patchRuntimeModuleLayer(runtimeModuleLayer, nameToModule, parentLayers, servicesCatalog);
             return runtimeModuleLayer;
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException ex) {
             throw VMError.shouldNotReachHere("Failed to synthesize the runtime module layer: " + runtimeModuleLayer, ex);
@@ -770,7 +772,7 @@ public final class ModuleLayerFeature implements InternalFeature {
         }
 
         public Module getRuntimeModuleForHostedModule(ClassLoader hostedLoader, String hostedModuleName, boolean optional) {
-            ClassLoader loader = HostedSubstrateUtil.getRuntimeClassLoader(hostedLoader);
+            ClassLoader loader = ClassLoaderFeature.getRuntimeClassLoader(hostedLoader);
             Map<String, Module> loaderRuntimeModules = runtimeModules.get(loader);
             if (loaderRuntimeModules == null) {
                 if (optional) {
@@ -801,7 +803,7 @@ public final class ModuleLayerFeature implements InternalFeature {
         }
 
         public Module getOrCreateRuntimeModuleForHostedModule(ClassLoader hostedLoader, String hostedModuleName, ModuleDescriptor runtimeModuleDescriptor) {
-            ClassLoader loader = HostedSubstrateUtil.getRuntimeClassLoader(hostedLoader);
+            ClassLoader loader = ClassLoaderFeature.getRuntimeClassLoader(hostedLoader);
             synchronized (runtimeModules) {
                 Module runtimeModule = getRuntimeModuleForHostedModule(loader, hostedModuleName, true);
                 if (runtimeModule != null) {
@@ -1032,9 +1034,8 @@ public final class ModuleLayerFeature implements InternalFeature {
             moduleLayerParentsField.set(moduleLayer, parents);
         }
 
-        void patchModuleLayerServicesCatalogField(AnalysisAccessBase accessImpl, ModuleLayer moduleLayer, ServicesCatalog servicesCatalog) throws IllegalAccessException {
+        void patchModuleLayerServicesCatalogField(ModuleLayer moduleLayer, ServicesCatalog servicesCatalog) throws IllegalAccessException {
             moduleLayerServicesCatalogField.set(moduleLayer, servicesCatalog);
-            accessImpl.rescanField(moduleLayer, moduleLayerServicesCatalogField);
         }
 
         ClassLoader getClassLoaderForBootLayerModule(String name) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ModuleLayerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ModuleLayerFeature.java
@@ -24,8 +24,6 @@
  */
 package com.oracle.svm.hosted;
 
-import static com.oracle.svm.core.util.VMError.shouldNotReachHereAtRuntime;
-
 import java.lang.module.Configuration;
 import java.lang.module.FindException;
 import java.lang.module.ModuleDescriptor;
@@ -67,14 +65,18 @@ import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.jdk.Resources;
+import com.oracle.svm.core.jdk.RuntimeClassLoaderValueSupport;
 import com.oracle.svm.core.jdk.RuntimeModuleSupport;
+import com.oracle.svm.core.util.HostedSubstrateUtil;
 import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.hosted.FeatureImpl.AnalysisAccessBase;
 import com.oracle.svm.util.LogUtils;
 import com.oracle.svm.util.ModuleSupport;
 import com.oracle.svm.util.ReflectionUtil;
 
 import jdk.internal.module.DefaultRoots;
 import jdk.internal.module.ModuleBootstrap;
+import jdk.internal.module.ServicesCatalog;
 import jdk.internal.module.SystemModuleFinders;
 
 /**
@@ -195,9 +197,15 @@ public final class ModuleLayerFeature implements InternalFeature {
             runtimeImageNamedModules.add((Module) module.get());
         });
 
+        /*
+         * We need to include synthetic modules in the runtime module system. Some modules, such as
+         * jdk.proxy, are created for all class loaders, so we need to make sure to not include
+         * those made for the builder class loader.
+         */
         Set<Module> analysisReachableSyntheticModules = runtimeImageNamedModules
                         .stream()
                         .filter(ModuleLayerFeatureUtils::isModuleSynthetic)
+                        .filter(m -> m.getClassLoader() != accessImpl.imageClassLoader.getClassLoader())
                         .collect(Collectors.toSet());
 
         /*
@@ -225,6 +233,7 @@ public final class ModuleLayerFeature implements InternalFeature {
         List<ModuleLayer> runtimeModuleLayers = synthesizeRuntimeModuleLayers(accessImpl, reachableModuleLayers, runtimeImageNamedModules, analysisReachableSyntheticModules, rootModules);
         ModuleLayer runtimeBootLayer = runtimeModuleLayers.get(0);
         RuntimeModuleSupport.instance().setBootLayer(runtimeBootLayer);
+        RuntimeClassLoaderValueSupport.instance().update(runtimeModuleLayers);
 
         /*
          * Ensure that runtime modules have the same relations (i.e., reads, opens and exports) as
@@ -426,11 +435,20 @@ public final class ModuleLayerFeature implements InternalFeature {
                 nameToModule.putIfAbsent(runtimeSyntheticModule.getName(), runtimeSyntheticModule);
                 moduleLayerFeatureUtils.patchModuleLayerField(runtimeSyntheticModule, runtimeModuleLayer);
             }
-            patchRuntimeModuleLayer(runtimeModuleLayer, nameToModule, parentLayers);
+            ServicesCatalog servicesCatalog = synthesizeRuntimeModuleLayerServicesCatalog(nameToModule);
+            patchRuntimeModuleLayer(accessImpl, runtimeModuleLayer, nameToModule, parentLayers, servicesCatalog);
             return runtimeModuleLayer;
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException ex) {
             throw VMError.shouldNotReachHere("Failed to synthesize the runtime module layer: " + runtimeModuleLayer, ex);
         }
+    }
+
+    private static ServicesCatalog synthesizeRuntimeModuleLayerServicesCatalog(Map<String, Module> nameToModule) {
+        ServicesCatalog servicesCatalog = ServicesCatalog.create();
+        for (Module m : nameToModule.values()) {
+            servicesCatalog.register(m);
+        }
+        return servicesCatalog;
     }
 
     private void replicateVisibilityModifications(ModuleLayer runtimeBootLayer, ImageClassLoader cl, Set<Module> analysisReachableNamedModules,
@@ -565,10 +583,11 @@ public final class ModuleLayerFeature implements InternalFeature {
         }
     }
 
-    private void patchRuntimeModuleLayer(ModuleLayer runtimeModuleLayer, Map<String, Module> nameToModule, List<ModuleLayer> parents) {
+    private void patchRuntimeModuleLayer(ModuleLayer runtimeModuleLayer, Map<String, Module> nameToModule, List<ModuleLayer> parents, ServicesCatalog servicesCatalog) {
         try {
             moduleLayerFeatureUtils.patchModuleLayerNameToModuleField(runtimeModuleLayer, nameToModule);
             moduleLayerFeatureUtils.patchModuleLayerParentsField(runtimeModuleLayer, parents);
+            moduleLayerFeatureUtils.patchModuleLayerServicesCatalogField(runtimeModuleLayer, servicesCatalog);
         } catch (IllegalAccessException ex) {
             throw VMError.shouldNotReachHere("Failed to patch the runtime boot module layer.", ex);
         }
@@ -603,6 +622,7 @@ public final class ModuleLayerFeature implements InternalFeature {
         private final Constructor<ModuleLayer> moduleLayerConstructor;
         private final Field moduleLayerNameToModuleField;
         private final Field moduleLayerParentsField;
+        private final Field moduleLayerServicesCatalogField;
 
         ModuleLayerFeatureUtils(ImageClassLoader cl) {
             runtimeModules = new HashMap<>();
@@ -658,6 +678,7 @@ public final class ModuleLayerFeature implements InternalFeature {
                 moduleLayerConstructor = ReflectionUtil.lookupConstructor(ModuleLayer.class, Configuration.class, List.class, Function.class);
                 moduleLayerNameToModuleField = ReflectionUtil.lookupField(ModuleLayer.class, "nameToModule");
                 moduleLayerParentsField = ReflectionUtil.lookupField(ModuleLayer.class, "parents");
+                moduleLayerServicesCatalogField = ReflectionUtil.lookupField(ModuleLayer.class, "servicesCatalog");
             } catch (ReflectiveOperationException | NoSuchElementException ex) {
                 throw VMError.shouldNotReachHere("Failed to retrieve fields of the Module/ModuleLayer class.", ex);
             }
@@ -748,7 +769,8 @@ public final class ModuleLayerFeature implements InternalFeature {
             }
         }
 
-        public Module getRuntimeModuleForHostedModule(ClassLoader loader, String hostedModuleName, boolean optional) {
+        public Module getRuntimeModuleForHostedModule(ClassLoader hostedLoader, String hostedModuleName, boolean optional) {
+            ClassLoader loader = HostedSubstrateUtil.getRuntimeClassLoader(hostedLoader);
             Map<String, Module> loaderRuntimeModules = runtimeModules.get(loader);
             if (loaderRuntimeModules == null) {
                 if (optional) {
@@ -778,7 +800,8 @@ public final class ModuleLayerFeature implements InternalFeature {
             }
         }
 
-        public Module getOrCreateRuntimeModuleForHostedModule(ClassLoader loader, String hostedModuleName, ModuleDescriptor runtimeModuleDescriptor) {
+        public Module getOrCreateRuntimeModuleForHostedModule(ClassLoader hostedLoader, String hostedModuleName, ModuleDescriptor runtimeModuleDescriptor) {
+            ClassLoader loader = HostedSubstrateUtil.getRuntimeClassLoader(hostedLoader);
             synchronized (runtimeModules) {
                 Module runtimeModule = getRuntimeModuleForHostedModule(loader, hostedModuleName, true);
                 if (runtimeModule != null) {
@@ -1007,6 +1030,11 @@ public final class ModuleLayerFeature implements InternalFeature {
 
         void patchModuleLayerParentsField(ModuleLayer moduleLayer, List<ModuleLayer> parents) throws IllegalAccessException {
             moduleLayerParentsField.set(moduleLayer, parents);
+        }
+
+        void patchModuleLayerServicesCatalogField(AnalysisAccessBase accessImpl, ModuleLayer moduleLayer, ServicesCatalog servicesCatalog) throws IllegalAccessException {
+            moduleLayerServicesCatalogField.set(moduleLayer, servicesCatalog);
+            accessImpl.rescanField(moduleLayer, moduleLayerServicesCatalogField);
         }
 
         ClassLoader getClassLoaderForBootLayerModule(String name) {


### PR DESCRIPTION
---------------
This is an attempt to backport commit mentioned in Oracle GraalVM for JDK 21.0.7 changelog #66

change name:
Fixed ServiceLoader based on module-info.java not working when generating a native image. GraalWasm

issue: https://github.com/oracle/graal/issues/9952
[Native Image] Missing support for ServiceLoader services registered via module-info #9952

PR: https://github.com/oracle/graal/pull/10202/files
 [GR-49635] [GR-59954] Update ClassLoaderValue maps to properly support modular service loading #10202
 
---------------

- original commit: https://github.com/oracle/graal/pull/10202/files
- [GR-49635] [GR-59954] Update ClassLoaderValue maps to properly support modular service loading
- Depends on (HostedSubstrateUtil introduced in):
	- https://github.com/oracle/graal/commit/6e1388b6be6816785365801ff20c653005504078
	- [GR-60044] Use runtime ClassLoader for unique name support.
	- Depends (HostedMethodNameFactory.java) on:
		- https://github.com/oracle/graal/commit/5b4716da36d140d32c5ccea684eb4b8d77368175
		- [GR-57248] Make HostedMethod naming layer-aware

To avoid these dependencies, HostedSubstrateUtil.getRuntimeClassLoader is replaced to direct ClassLoaderFeature.getRuntimeClassLoader call
 
---------------