### PR TITLE
[Backport] [GR-54313] TruffleString: fix TruffleStringBuilder and RepeatNode breaking string compaction invariants

### DIFF
--- a/truffle/src/com.oracle.truffle.api.strings.test/src/com/oracle/truffle/api/strings/test/builder/TStringBuilderAppendSubStringTest.java
+++ b/truffle/src/com.oracle.truffle.api.strings.test/src/com/oracle/truffle/api/strings/test/builder/TStringBuilderAppendSubStringTest.java
@@ -68,15 +68,28 @@ public class TStringBuilderAppendSubStringTest extends TStringTestBase {
     public void testAll() throws Exception {
         forAllStrings(true, (a, arrayA, codeRangeA, isValidA, encodingA, codepointsA, byteIndicesA) -> {
             forAllStrings(new TruffleString.Encoding[]{encodingA}, true, (b, arrayB, codeRangeB, isValidB, encodingB, codepointsB, byteIndicesB) -> {
-                TruffleStringBuilder sb = TruffleStringBuilder.create(encodingA);
-                node.execute(sb, a, 0, arrayA.length);
-                int fromByteIndexB = codepointsB.length > 1 ? byteIndicesB[1] : 0;
-                int byteLengthB = (codepointsB.length > 2 ? byteIndicesB[codepointsB.length - 1] : arrayB.length) - fromByteIndexB;
-                assert byteLengthB > 0;
-                node.execute(sb, b, fromByteIndexB, byteLengthB);
-                byte[] expected = Arrays.copyOf(arrayA, arrayA.length + byteLengthB);
-                System.arraycopy(arrayB, fromByteIndexB, expected, arrayA.length, byteLengthB);
-                assertBytesEqual(sb.toStringUncached(), encodingA, expected);
+                forAllStrings(new TruffleString.Encoding[]{encodingA}, true, (c, arrayC, codeRangeC, isValidC, encodingC, codepointsC, byteIndicesC) -> {
+
+                    TruffleStringBuilder sb = TruffleStringBuilder.create(encodingA);
+                    node.execute(sb, a, 0, arrayA.length);
+                    int fromByteIndexB = codepointsB.length > 1 ? byteIndicesB[1] : 0;
+                    int byteLengthB = (codepointsB.length > 2 ? byteIndicesB[codepointsB.length - 1] : arrayB.length) - fromByteIndexB;
+                    assert byteLengthB > 0;
+                    node.execute(sb, b, fromByteIndexB, byteLengthB);
+                    byte[] expected = Arrays.copyOf(arrayA, arrayA.length + byteLengthB);
+                    System.arraycopy(arrayB, fromByteIndexB, expected, arrayA.length, byteLengthB);
+                    assertBytesEqual(sb.toStringUncached(), encodingA, expected);
+
+                    sb = TruffleStringBuilder.create(encodingA);
+                    node.execute(sb, a, 0, arrayA.length);
+                    TruffleString concat = b.concatUncached(c, encodingA, true);
+                    int fromByteIndex = b.byteLength(encodingA);
+                    int byteLength = c.byteLength(encodingA);
+                    node.execute(sb, concat, fromByteIndex, byteLength);
+                    expected = Arrays.copyOf(arrayA, arrayA.length + byteLength);
+                    System.arraycopy(arrayC, 0, expected, arrayA.length, byteLength);
+                    assertBytesEqual(sb.toStringUncached(), encodingA, expected);
+                });
             });
         });
     }

--- a/truffle/src/com.oracle.truffle.api.strings/src/com/oracle/truffle/api/strings/TruffleString.java
+++ b/truffle/src/com.oracle.truffle.api.strings/src/com/oracle/truffle/api/strings/TruffleString.java
@@ -216,6 +216,8 @@ public final class TruffleString extends AbstractTruffleString {
         }
         if (bytes instanceof NativePointer) {
             ((NativePointer) bytes).materializeByteArray(null, offset, length << stride, InlinedConditionProfile.getUncached());
+        } else {
+            assert stride == Stride.fromCodeRangeAllowImprecise(codeRange, encoding);
         }
         long attrs = CalcStringAttributesNodeGen.getUncached().execute(CalcStringAttributesNodeGen.getUncached(), null, bytes, offset, length, stride, encoding, 0, knownCodeRange);
         int cpLengthCalc = StringAttributes.getCodePointLength(attrs);
@@ -4942,7 +4944,8 @@ public final class TruffleString extends AbstractTruffleString {
                         @Cached TStringInternalNodes.GetCodePointLengthNode getCodePointLengthNode,
                         @Cached TStringInternalNodes.CalcStringAttributesNode calcStringAttributesNode,
                         @Cached InlinedConditionProfile brokenProfile,
-                        @Cached InlinedBranchProfile outOfMemoryProfile) {
+                        @Cached InlinedBranchProfile outOfMemoryProfile,
+                        @Cached InlinedBranchProfile compactProfile) {
             a.checkEncoding(expectedEncoding);
             if (n < 0) {
                 throw InternalErrors.illegalArgument("n must be positive");
@@ -4957,27 +4960,38 @@ public final class TruffleString extends AbstractTruffleString {
             int codeRangeA = getPreciseCodeRangeNode.execute(this, a, expectedEncoding);
             int codePointLengthA = getCodePointLengthNode.execute(this, a, expectedEncoding);
             int byteLengthA = (a.length()) << a.stride();
-            long byteLength = ((long) byteLengthA) * n;
+            int stride = Stride.fromCodeRange(codeRangeA, expectedEncoding);
+            long byteLength = (((long) a.length()) << stride) * n;
             if (Long.compareUnsigned(byteLength, TStringConstants.MAX_ARRAY_SIZE) > 0) {
                 outOfMemoryProfile.enter(this);
                 throw InternalErrors.outOfMemory();
             }
             byte[] array = new byte[(int) byteLength];
             int offsetB = 0;
-            for (int i = 0; i < n; i++) {
-                TStringOps.arraycopyWithStride(this, arrayA, a.offset(), 0, 0, array, offsetB, 0, 0, byteLengthA);
-                offsetB += byteLengthA;
-                TStringConstants.truffleSafePointPoll(this, i + 1);
+            if (stride == a.stride()) {
+                for (int i = 0; i < n; i++) {
+                    TStringOps.arraycopyWithStride(this, arrayA, a.offset(), 0, 0, array, offsetB, 0, 0, byteLengthA);
+                    offsetB += byteLengthA;
+                    TStringConstants.truffleSafePointPoll(this, i + 1);
+                }
+            } else {
+                compactProfile.enter(this);
+                int byteLengthCompact = a.length() << stride;
+                for (int i = 0; i < n; i++) {
+                    TStringOps.arraycopyWithStride(this, arrayA, a.offset(), a.stride(), 0, array, offsetB, stride, 0, a.length());
+                    offsetB += byteLengthCompact;
+                    TStringConstants.truffleSafePointPoll(this, i + 1);
+                }
             }
-            int length = (int) (byteLength >> a.stride());
+            int length = (int) (byteLength >> stride);
             if (brokenProfile.profile(this, isBroken(codeRangeA))) {
-                long attrs = calcStringAttributesNode.execute(this, null, array, 0, length, a.stride(), expectedEncoding, 0, codeRangeA);
+                long attrs = calcStringAttributesNode.execute(this, null, array, 0, length, stride, expectedEncoding, 0, codeRangeA);
                 codeRangeA = StringAttributes.getCodeRange(attrs);
                 codePointLengthA = StringAttributes.getCodePointLength(attrs);
             } else {
                 codePointLengthA *= n;
             }
-            return createFromByteArray(array, length, a.stride(), expectedEncoding, codePointLengthA, codeRangeA);
+            return createFromByteArray(array, length, stride, expectedEncoding, codePointLengthA, codeRangeA);
         }
 
         /**


### PR DESCRIPTION
<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**
- https://github.com/oracle/graal/pull/9016/

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

**Testing:** unittest provided

<!-- Add the backport issue that this PR closes -->
**Closes:** This is a part of [[Backport] Oracle GraalVM for JDK 21.0.7 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/66) effort
