### PR TITLE
[Backport][GR-61481] Fix tier_count values in CPU sampler JSON output.

### DIFF
--- a/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/CPUSamplerCLI.java
+++ b/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/CPUSamplerCLI.java
@@ -366,7 +366,7 @@ class CPUSamplerCLI extends ProfilerCLI {
             sample.put("self_tier_count", selfTierCount);
             int[] tierCount = new int[payload.getNumberOfTiers()];
             for (int i = 0; i < tierCount.length; i++) {
-                tierCount[i] = payload.getTierSelfCount(i);
+                tierCount[i] = payload.getTierTotalCount(i);
             }
             sample.put("tier_count", tierCount);
             sample.put("children", getSamplesRec(node.getChildren()));


### PR DESCRIPTION
<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**
- https://github.com/oracle/graal/pull/10524
  - a simple change to correct CPU sampler’s tier_count value

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

**Testing:** tools/mx.tools unit tests: no regressions.

<!-- Add the backport issue that this PR closes -->
**This PR is a part of the** [Oracle GraalVM for JDK 21.0.7 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/66)