### PR TITLE
[Backport][GR-60578] Upgrade ASM dependency from 9.5 to 9.7.1.

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -85,33 +85,39 @@ suite = {
       "urls" : ["https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/batik-all-1.7.jar"],
     },
 
-    "ASM_9.5" : {
-      "digest" : "sha512:9e65f2983783725bae196ca939b45246958731246df1c495089c8ea5ce646de77c4e01a5a9ba10642016bb3258e1727e9ebcece6e74d9e3c32f528025d76b955",
+    "ASM_9.7.1" : {
+      "digest" : "sha512:4767b01603dad5c79cc1e2b5f3722f72b1059d928f184f446ba11badeb1b381b3a3a9a801cc43d25d396df950b09d19597c73173c411b1da890de808b94f1f50",
+      "sourceDigest" : "sha512:d7c0de5912d04949a3d06cad366ff35a877da2682d9c74579625d62686032ea9349aff6102b17f92e9ec7eb4e9b1cd906b649c6a3ac798bfb9e31e5425de009d",
       "maven" : {
         "groupId" : "org.ow2.asm",
         "artifactId" : "asm",
-        "version" : "9.5",
+        "version" : "9.7.1",
       },
+      "license" : "BSD-new",
     },
 
-    "ASM_TREE_9.5" : {
-      "digest" : "sha512:816de8f84c216a7bd97b2458bde64a4b99a039b7b59fbd1ef52edf8bf869edabb93967736fe0c61e8eb3e1520e0cefe69ba59cda12df30f9f85db75fb6c064f3",
+    "ASM_TREE_9.7.1" : {
+      "digest" : "sha512:e55008c392fdd35e95d3404766b12dd4b46e13d5c362fcd0ab42a65751a82737eaf0ebc857691d1916190d34407adfde4437615d69c278785416fd911e00978d",
+      "sourceDigest" : "sha512:3cea80bc7b55679dfa3d2065c6cb6951007cc7817082e9fcf4c5e3cdc073c22eddf7c7899cff60b1092049ec9038e8d3aa9a8828ef731739bda8b5afcec30e86",
       "maven" : {
         "groupId" : "org.ow2.asm",
         "artifactId" : "asm-tree",
-        "version" : "9.5",
+        "version" : "9.7.1",
       },
-      "dependencies" : ["ASM_9.5"],
+      "dependencies" : ["ASM_9.7.1"],
+      "license" : "BSD-new",
     },
 
-    "ASM_UTIL_9.5" : {
-      "digest" : "sha512:f68284d8f8fd029f3f428112225b2035ed3a4216cf3b34e0aacc83c32a6d44ab5e5d128b60a13ef768e3396041a62cf63f7fd3445dc5a05ce0ae03a2b2ed3080",
+    "ASM_UTIL_9.7.1" : {
+      "digest" : "sha512:522d793d15a2c5ea6504a50222cf0750f1eab7b881cf289675042539b1aba8b3868197b1bebe729de728dd10020eb028ae16252dcd5d84fdcbf7f925832bc269",
+      "sourceDigest" : "sha512:387aa887bfec24aec287d9aacebfdc0c2e1ab16a4adce933aecac6fc41545ce43a3eea0ed139db52dd0d0af910cfd2162aa4d6330a81b32b64b36f03b49db66a",
       "maven" : {
         "groupId" : "org.ow2.asm",
         "artifactId" : "asm-util",
-        "version" : "9.5",
+        "version" : "9.7.1",
       },
-      "dependencies" : ["ASM_9.5"],
+      "dependencies" : ["ASM_9.7.1"],
+      "license" : "BSD-new",
     },
 
     "HSDIS" : {
@@ -236,8 +242,8 @@ suite = {
       "dependencies" : [
         "jdk.internal.vm.compiler",
         "mx:JUNIT",
-        "ASM_TREE_9.5",
-        "ASM_UTIL_9.5",
+        "ASM_TREE_9.7.1",
+        "ASM_UTIL_9.7.1",
         "JAVA_ALLOCATION_INSTRUMENTER",
         "truffle:TRUFFLE_SL_TEST",
         "truffle:TRUFFLE_TEST",
@@ -456,8 +462,8 @@ suite = {
         "truffle:TRUFFLE_COMPILER",
         "truffle:TRUFFLE_RUNTIME",
         "regex:TREGEX",
-        "ASM_TREE_9.5",
-        "ASM_UTIL_9.5",
+        "ASM_TREE_9.7.1",
+        "ASM_UTIL_9.7.1",
       ],
       "exclude" : [
         "mx:JUNIT",

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -111,7 +111,7 @@ suite = {
             "dependencies": [
                 "truffle:TRUFFLE_API",
                 "truffle:TRUFFLE_NFI",
-                "truffle:TRUFFLE_ASM_9.5",
+                "truffle:TRUFFLE_ASM_9.7.1",
                 "com.oracle.truffle.espresso.jdwp",
             ],
             "requires": [

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -105,9 +105,9 @@ suite = {
       "license": ["MIT"],
     },
 
-    "TRUFFLE_ASM_9.5" : {
-      "digest" : "sha512:7a49aaa0c4b513ca54ce684a74a3848ba4caf486320125f08cb8872720dc1e789538729f45c46d6ccf1b1ea54f7c3770dc9682d13a3f1813a348168ee5c40b82",
-      "urls": ["https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/com.oracle.truffle.api.impl.asm-9.5.0.jar"],
+    "TRUFFLE_ASM_9.7.1" : {
+      "digest" : "sha512:e677171df27f646c84f078d5a6256a84c871c0b02088953f204c424f61ad453fc52726370fc3f5bd5e6ba6bf70d4c0c735d09a5c3e298db289ae4c9e628b4c57",
+      "urls": ["https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/com.oracle.truffle.api.impl.asm-9.7.1.jar"],
     },
 
     "ICU4J" : {
@@ -304,7 +304,7 @@ suite = {
       "sourceDirs" : ["src"],
       "dependencies" : [
         "com.oracle.truffle.api.exception",
-        "truffle:TRUFFLE_ASM_9.5",
+        "truffle:TRUFFLE_ASM_9.7.1",
       ],
       "requires" : [
         "java.sql",
@@ -638,7 +638,7 @@ suite = {
       "sourceDirs" : ["src"],
       "dependencies" : [
         "com.oracle.truffle.api",
-        "truffle:TRUFFLE_ASM_9.5",
+        "truffle:TRUFFLE_ASM_9.7.1",
       ],
       "requires" : [
         "jdk.unsupported", # sun.misc.Unsafe


### PR DESCRIPTION
<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**
- https://github.com/oracle/graal/pull/10331

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
- mx.espresso: extra change on mainline: "Espresso should use its own shadowed copy of ASM rather than Truffle's."
  - https://github.com/oracle/graal/commit/b3b83abdcec1c26f7e740144aabc991636e7cb20
- mx.truffle: extra change on mainline: "Shadow ASM for truffle module from source using mx."
  - https://github.com/oracle/graal/commit/02467c20f4a3a80d6acfdc377eababe238436f7f
- resolution: manual url update

<!-- Add the backport issue that this PR closes -->
**This PR is a part of the** [Oracle GraalVM for JDK 21.0.7 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/66)