### PR TITLE
[Backport][GR-61882] Backport to 23.1: Upgrading the underlying Node.js to version 18.20.6.

### DIFF
--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -33,7 +33,7 @@ suite = {
                 "name": "graal-nodejs",
                 "subdir": True,
                 "dynamic": True,
-                "version": "2e77deef4a104c3dfe8724aad8ae7a4a1d586fc8",
+                "version": "72b6712f96bda65ee99bef409b4198bee4d4fb7d",
                 "urls" : [
                     {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -42,7 +42,7 @@ suite = {
                 "name": "graal-js",
                 "subdir": True,
                 "dynamic": True,
-                "version": "2e77deef4a104c3dfe8724aad8ae7a4a1d586fc8",
+                "version": "72b6712f96bda65ee99bef409b4198bee4d4fb7d",
                 "urls": [
                     {"url": "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]


### PR DESCRIPTION
<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**

This PR aligns the Node.js version upgrade with the Oracle Graal 21.0.7 release. In our mainline history, the Node.js versions have advanced as follows.

```
commit 3ddc33a7288714e2760db6f8bb2e2cbb6f2a833f
Author: Jan Stola <jan.stola@oracle.com>
Date:   Tue May 20 10:53:45 2025 +0000

    [GR-65024] Upgrading the underlying Node.js to version 22.15.1.
--
commit 0f852099918cb09f0fdab18656d5e1cf74d890f2
Author: Jan Stola <jan.stola@oracle.com>
Date:   Tue Jul 23 20:40:41 2024 +0000

    [GR-55200] Upgrading the underlying Node.js to version 20.15.1.
--
commit 08170ef96e1d072fb69c53d403d14a654e12802a
Author: Jan Stola <jan.stola@oracle.com>
Date:   Thu May 23 02:32:02 2024 +0000

    [GR-54168] Upgrading the underlying Node.js to version 20.13.1.
--
commit fadd2a19cb4f3e1a14e729f2baca6a6d050dfd76
Author: Jan Stola <jan.stola@oracle.com>
Date:   Fri Nov 3 01:22:22 2023 +0000

    [GR-49506] Upgrading the underlying Node.js to version 18.18.2.
```

Node.js version 18.20.6 was skipped in mainline, but was applied in Oracle Graal 21.0.7 release. This change is not a cherry-pick. It updates the Node.js to version 18.20.6 (consistent with previous updates): https://github.com/oracle/graaljs/commit/72b6712f96bda65ee99bef409b4198bee4d4fb7d 

<!-- Add the backport issue that this PR closes -->
**This PR is a part of the** [Oracle GraalVM for JDK 21.0.7 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/66)