### PR TITLE
[Backport] [Oracle GraalVM] [GR-63188] Backport to 23.1: Verify that DynamicHubs are addressable.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ChunkedImageHeapLayouter.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ChunkedImageHeapLayouter.java
@@ -82,7 +82,7 @@ public class ChunkedImageHeapLayouter extends AbstractImageHeapLayouter<ChunkedI
         for (ChunkedImageHeapPartition partition : getPartitions()) {
             partition.layout(allocator);
         }
-        return populateInfoObjects(imageHeap.countDynamicHubs());
+        return populateInfoObjects(imageHeap.countAndVerifyDynamicHubs());
     }
 
     private ImageHeapLayoutInfo populateInfoObjects(int dynamicHubCount) {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LinearImageHeapLayouter.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LinearImageHeapLayouter.java
@@ -61,7 +61,7 @@ public class LinearImageHeapLayouter extends AbstractImageHeapLayouter<LinearIma
         for (LinearImageHeapPartition partition : getPartitions()) {
             partition.allocateObjects(allocator);
         }
-        initializeHeapInfo(imageHeap.countDynamicHubs());
+        initializeHeapInfo(imageHeap.countAndVerifyDynamicHubs());
         return createLayoutInfo(startOffset, getWritablePrimitive().getStartOffset());
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ObjectHeaderImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ObjectHeaderImpl.java
@@ -295,7 +295,6 @@ public final class ObjectHeaderImpl extends ObjectHeader {
     @Override
     public long encodeAsImageHeapObjectHeader(ImageHeapObject obj, long hubOffsetFromHeapBase) {
         long header = hubOffsetFromHeapBase << numReservedExtraBits;
-        VMError.guarantee((header >>> numReservedExtraBits) == hubOffsetFromHeapBase, "Hub is too far from heap base for encoding in object header");
         assert (header & reservedBitsMask) == 0 : "Object header bits must be zero initially";
         if (HeapImpl.usesImageHeapCardMarking()) {
             if (obj.getPartition() instanceof ChunkedImageHeapPartition partition) {
@@ -313,6 +312,16 @@ public final class ObjectHeaderImpl extends ObjectHeader {
             header |= (IDHASH_STATE_IN_FIELD.rawValue() << IDHASH_STATE_SHIFT);
         }
         return header;
+    }
+
+    @Override
+    public void verifyDynamicHubOffsetInImageHeap(long offsetFromHeapBase) {
+        long referenceSizeMask = getReferenceSize() == Integer.BYTES ? 0xFFFF_FFFFL : -1L;
+        long encoded = (offsetFromHeapBase << numReservedExtraBits) & referenceSizeMask;
+        boolean shiftLosesInformation = (encoded >>> numReservedExtraBits != offsetFromHeapBase);
+        if (shiftLosesInformation) {
+            throw VMError.shouldNotReachHere("Hub is too far from heap base for encoding in object header: " + offsetFromHeapBase);
+        }
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ObjectHeader.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ObjectHeader.java
@@ -63,6 +63,8 @@ public abstract class ObjectHeader {
 
     public abstract Word encodeAsUnmanagedObjectHeader(DynamicHub hub);
 
+    public abstract void verifyDynamicHubOffsetInImageHeap(long offsetFromHeapBase);
+
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public DynamicHub dynamicHubFromObjectHeader(Word header) {
         return (DynamicHub) extractPotentialDynamicHubFromHeader(header).toObject();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/image/ImageHeap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/image/ImageHeap.java
@@ -33,5 +33,5 @@ public interface ImageHeap {
 
     ImageHeapObject addFillerObject(int size);
 
-    int countDynamicHubs();
+    int countAndVerifyDynamicHubs();
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageHeap.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageHeap.java
@@ -61,6 +61,7 @@ import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.config.ObjectLayout;
 import com.oracle.svm.core.heap.FillerObject;
 import com.oracle.svm.core.heap.Heap;
+import com.oracle.svm.core.heap.ObjectHeader;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.hub.DynamicHubCompanion;
 import com.oracle.svm.core.hub.LayoutEncoding;
@@ -371,10 +372,12 @@ public final class NativeImageHeap implements ImageHeap {
     }
 
     @Override
-    public int countDynamicHubs() {
+    public int countAndVerifyDynamicHubs() {
+        ObjectHeader objHeader = Heap.getHeap().getObjectHeader();
         int count = 0;
         for (ObjectInfo o : getObjects()) {
             if (hMetaAccess.isInstanceOf(o.getConstant(), DynamicHub.class)) {
+                objHeader.verifyDynamicHubOffsetInImageHeap(o.getOffset());
                 count++;
             }
         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageHeapWriter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageHeapWriter.java
@@ -234,7 +234,7 @@ public final class NativeImageHeapWriter {
         DynamicHub hub = obj.getClazz().getHub();
         assert hub != null : "Null DynamicHub found during native image generation.";
         ObjectInfo hubInfo = heap.getObjectInfo(hub);
-        assert hubInfo != null : "Unknown object " + hub.toString() + " found. Static field or an object referenced from a static field changed during native image generation?";
+        assert hubInfo != null : "Unknown object " + hub + " found. Static field or an object referenced from a static field changed during native image generation?";
 
         ObjectHeader objectHeader = Heap.getHeap().getObjectHeader();
         if (NativeImageHeap.useHeapBase()) {
@@ -312,7 +312,7 @@ public final class NativeImageHeapWriter {
         if (referenceSize() == Long.BYTES) {
             buffer.getByteBuffer().putLong(index, value);
         } else if (referenceSize() == Integer.BYTES) {
-            buffer.getByteBuffer().putInt(index, NumUtil.safeToInt(value));
+            buffer.getByteBuffer().putInt(index, NumUtil.safeToUInt(value));
         } else {
             throw shouldNotReachHere("Unsupported reference size: " + referenceSize());
         }


### PR DESCRIPTION
[Backport] [Oracle GraalVM] [GR-63188] Backport to 23.1: Verify that DynamicHubs are addressable.

(cherry picked from commit cb07bf7cf6c67e25f9aa7edfdf8724e4e46db543)

<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**
- https://github.com/oracle/graal/pull/10826

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 
`substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ChunkedImageHeapLayouter.java`: In `ChunkedImageHeapLayouter.doLayout`; resolved by calling `populateInfoObjects(imageHeap.countAndVerifyDynamicHubs())`

`substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageHeap.java`: In `countAndVerifyDynamicHubs()`: 
```
<<<<<<< HEAD
            if (hMetaAccess.isInstanceOf(o.getConstant(), DynamicHub.class)) {
||||||| parent of cb07bf7cf6c (Verify that DynamicHubs are addressable.)
            if (!o.constant.isWrittenInPreviousLayer() && hMetaAccess.isInstanceOf(o.getConstant(), DynamicHub.class)) {
=======
            if (!o.constant.isWrittenInPreviousLayer() && hMetaAccess.isInstanceOf(o.getConstant(), DynamicHub.class)) {
                objHeader.verifyDynamicHubOffsetInImageHeap(o.getOffset());
>>>>>>> cb07bf7cf6c (Verify that DynamicHubs are addressable.)
```
Kept existing code without the `!o.constant.isWrittenInPreviousLayer()`, as this doesn't seem to exist in the current codebase.

<!-- Add the backport issue that this PR closes -->
**Closes:** https://github.com/graalvm/graalvm-community-jdk21u/issues/70
