### PR TITLE
Fix UnixFileSystemAccessors.reinitialize(...).

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/FileSystemProviderSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/FileSystemProviderSupport.java
@@ -49,6 +49,8 @@ import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.option.HostedOptionKey;
 
+import jdk.internal.util.StaticProperty;
+
 public final class FileSystemProviderSupport {
 
     public static class Options {
@@ -193,12 +195,12 @@ final class Target_sun_nio_fs_UnixFileSystem {
     private Target_sun_nio_fs_UnixPath rootDirectory;
 
     /**
-     * Flag to check if re-initialization at run time already happened. The initial value of this
-     * flag in the image heap is non-zero, and it is set to zero when re-initialization is done.
-     * This ensures that UnixFileSystem instances allocated at run time are not re-initialized,
-     * because they are allocated with the field value. Note that UnixFileSystem instances should
-     * not be allocated at run time, since only the singleton from the image heap should exist.
-     * However, there were JDK bugs in various JDK versions where unwanted allocations happened.
+     * Flag to check if reinitialization at run time is needed. For objects in the image heap, this
+     * field is initially non-zero and set to zero after reinitialization. If UnixFileSystem
+     * instances are allocated at run time, the field will be set to zero right away (default value)
+     * as there is no need for reinitialization. Note that UnixFileSystem instances should not be
+     * allocated at run time, as only the singleton from the image heap should exist. However, there
+     * were JDK bugs in various JDK versions where unwanted allocations happened.
      */
     @Inject //
     @RecomputeFieldValue(kind = Kind.Custom, declClass = NeedsReinitializationProvider.class)//
@@ -293,6 +295,10 @@ class UnixFileSystemAccessors {
         that.injectedRootDirectory = value;
     }
 
+    // @BasedOnJDKFile("https://github.com/openjdk/jdk21u-dev/blob/jdk-21.0.7-ga/src/java.base/linux/classes/sun/nio/fs/LinuxFileSystem.java#L44-L46")
+    // @BasedOnJDKFile("https://github.com/openjdk/jdk21u-dev/blob/jdk-21.0.7-ga/src/java.base/linux/classes/sun/nio/fs/LinuxFileSystemProvider.java#L45-L47")
+    // @BasedOnJDKFile("https://github.com/openjdk/jdk21u-dev/blob/jdk-21.0.7-ga/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java#L77-L79")
+    // @BasedOnJDKFile("https://github.com/openjdk/jdk21u-dev/blob/jdk-21.0.7-ga/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java#L80-L107")
     private static synchronized void reinitialize(Target_sun_nio_fs_UnixFileSystem that) {
         if (that.needsReinitialization != NeedsReinitializationProvider.STATUS_NEEDS_REINITIALIZATION) {
             /* Field initialized is volatile, so double-checked locking is OK. */
@@ -309,10 +315,10 @@ class UnixFileSystemAccessors {
          * with the same value it is already set to, so this is harmless. All other field writes are
          * redirected to the set-accessors of this class and write the injected fields.
          *
-         * Note that the `System.getProperty("user.dir")` value is always used when re-initializing
-         * a UnixFileSystem, which is not the case with the WindowsFileSystem (JDK-8066709).
+         * Note that the `StaticProperty.userDir()` value is always used when re-initializing a
+         * UnixFileSystem, which is not the case with the WindowsFileSystem (JDK-8066709).
          */
-        that.originalConstructor(that.provider, System.getProperty("user.dir"));
+        that.originalConstructor(that.provider, StaticProperty.userDir());
 
         /*
          * Now the object is completely re-initialized and can be used by any thread without


### PR DESCRIPTION
Closes: #114 

There were conflicts due to `user.dir` vs. `UserSystemProperty.DIR` change in head. Also the `@BasedOnJDKFile` annotation isn't present in the JDK 21 community tree. I've also updated references to JDK 21.0.7 over JDK 25 (in head). Since `StaticProperty` wasn't used before in `FileSystemProviderSupport.java` that import is new.

(cherry picked from commit d0cb4a052538a7f7d009bc875eb5bd9ac84cbb3a)
