### PR TITLE
[Backport] [Oracle GraalVM] [GR-63196] Backport to 23.1: Fix incorrect usages of VMError.guaranteeInProgress(...)

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
@@ -429,7 +429,7 @@ public final class ThreadLocalAllocation {
     }
 
     static void disableAndFlushForAllThreads() {
-        VMOperation.guaranteeInProgress("ThreadLocalAllocation.disableAndFlushForAllThreads");
+        VMOperation.guaranteeInProgressAtSafepoint("ThreadLocalAllocation.disableAndFlushForAllThreads");
 
         if (SubstrateOptions.MultiThreaded.getValue()) {
             for (IsolateThread vmThread = VMThreads.firstThread(); vmThread.isNonNull(); vmThread = VMThreads.nextThread(vmThread)) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Uninterruptible.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Uninterruptible.java
@@ -41,7 +41,6 @@ import org.graalvm.nativeimage.c.function.InvokeCFunctionPointer;
 import org.graalvm.word.WordBase;
 
 import com.oracle.svm.core.snippets.KnownIntrinsics;
-import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.util.ReflectionUtil;
 
@@ -88,16 +87,6 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
  * is so simple that it can always be inlined into interruptible code, the method can be annotated
  * with {@link #mayBeInlined "mayBeInlined = true"}. Uninterruptible methods can always be inlined
  * into other uninterruptible methods.
- * <dl>
- * Some alternatives to annotation:
- * <dt>Code called from snippets</dt>
- * <dd>Snippet code is always inlined and runs to completion. Methods called only from snippets need
- * not be annotated.</dd>
- * <dt>Code called from VMOperations</dt>
- * <dd>VMOperation code runs single-threaded to completion. Public entry points that should only run
- * in VMOperations can be guarded with a call to
- * {@linkplain VMOperation#guaranteeInProgress(String)}.</dd>
- * </dl>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/deopt/Deoptimizer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/deopt/Deoptimizer.java
@@ -311,7 +311,7 @@ public final class Deoptimizer {
                     "Note that we could start the stack frame also further down the stack, because VM operation frames never need deoptimization. " +
                     "But we don't store stack frame information for the first frame we would need to process.")
     private static void deoptimizeInRangeOperation(CodePointer fromIp, CodePointer toIp, boolean deoptAll) {
-        VMOperation.guaranteeInProgress("Deoptimizer.deoptimizeInRangeOperation, but not in VMOperation.");
+        VMOperation.guaranteeInProgressAtSafepoint("Deoptimizer.deoptimizeInRangeOperation, but not in VMOperation.");
         /* Handle my own thread specially, because I do not have a JavaFrameAnchor. */
         Pointer sp = KnownIntrinsics.readCallerStackPointer();
 
@@ -394,7 +394,7 @@ public final class Deoptimizer {
     }
 
     private static void deoptimizeFrameOperation(Pointer sourceSp, boolean ignoreNonDeoptimizable, SpeculationReason speculation, IsolateThread targetThread) {
-        VMOperation.guaranteeInProgress("doDeoptimizeFrame");
+        VMOperation.guaranteeInProgressAtSafepoint("doDeoptimizeFrame");
         CodePointer returnAddress = FrameAccess.singleton().readReturnAddress(sourceSp);
         deoptimizeFrame(sourceSp, ignoreNonDeoptimizable, speculation, returnAddress, targetThread);
     }
@@ -683,7 +683,7 @@ public final class Deoptimizer {
     }
 
     private DeoptimizedFrame deoptSourceFrameOperation(CodePointer pc, boolean ignoreNonDeoptimizable) {
-        VMOperation.guaranteeInProgress("deoptSourceFrame");
+        VMOperation.guaranteeInProgressAtSafepoint("deoptSourceFrame");
 
         DeoptimizedFrame existing = checkDeoptimized(sourceSp);
         if (existing != null) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMOperation.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMOperation.java
@@ -117,7 +117,8 @@ public abstract class VMOperation {
     }
 
     /**
-     * Returns true if the current thread is currently executing a VM operation.
+     * Returns true if the current thread is in the middle of executing a VM operation. Note that
+     * this includes VM operations that do not need a safepoint.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static boolean isInProgress() {
@@ -126,7 +127,7 @@ public abstract class VMOperation {
     }
 
     /**
-     * Returns true if the current thread is currently executing a VM operation that causes a
+     * Returns true if the current thread is in the middle of executing a VM operation that needs a
      * safepoint.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
@@ -135,31 +136,36 @@ public abstract class VMOperation {
         return isInProgress(inProgress) && inProgress.operation.getCausesSafepoint();
     }
 
+    /**
+     * Returns true if the current thread is in the middle of executing a VM operation. Note that
+     * this includes VM operations that do not need a safepoint.
+     */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     static boolean isInProgress(OpInProgress inProgress) {
         return inProgress.getExecutingThread() == CurrentIsolate.getCurrentThread();
     }
 
+    /** Returns true if the current thread is in the middle of performing a garbage collection. */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static boolean isGCInProgress() {
         VMOperation op = VMOperationControl.get().getInProgress().getOperation();
         return op != null && op.isGC();
     }
 
-    /** Check that there is a VMOperation in progress. */
-    public static void guaranteeInProgress(String message) {
-        if (!isInProgress()) {
-            throw VMError.shouldNotReachHere(message);
-        }
-    }
-
-    /** Check that there is not a VMOperation in progress. */
+    /**
+     * Throws a fatal error if the current thread is in the middle of executing a VM operation. Note
+     * that this includes VM operations that do not need a safepoint.
+     */
     public static void guaranteeNotInProgress(String message) {
         if (isInProgress()) {
             throw VMError.shouldNotReachHere(message);
         }
     }
 
+    /**
+     * Verifies that the current thread is in the middle of executing a VM operation that needs a
+     * safepoint.
+     */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static void guaranteeInProgressAtSafepoint(String message) {
         if (!isInProgressAtSafepoint()) {
@@ -167,6 +173,7 @@ public abstract class VMOperation {
         }
     }
 
+    /** Verifies that the current thread is in the middle of performing a garbage collection. */
     public static void guaranteeGCInProgress(String message) {
         if (!isGCInProgress()) {
             throw VMError.shouldNotReachHere(message);


### PR DESCRIPTION
<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**
- https://github.com/oracle/graal/pull/10734

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
* `substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java`
* `substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Uninterruptible.java`
* `substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/deopt/Deoptimizer.java`

There were a few import conflicts, but `Deoptimizer.java` had many conflicts due to the addition of lazy deoptimization in upstream code.

<!-- Add the backport issue that this PR closes -->
**Closes:** https://github.com/graalvm/graalvm-community-jdk21u/issues/73
