### PR TITLE
[Backport] [Oracle GraalVM] [GR-65262] Backport to 23.1.8: Prevent new substitutions for bundle apply without create.

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -503,6 +503,11 @@ final class BundleSupport {
             return rootDir.resolve(previousRelativeSubstitutedPath);
         }
 
+        if (!this.writeBundle && destinationDir != auxiliaryOutputDir) {
+            /* If this is bundle-apply only, no new substitutions needed for input paths. */
+            return origPath;
+        }
+
         if (origPath.startsWith(nativeImage.config.getJavaHome())) {
             /* If origPath comes from native-image itself, substituting is not needed. */
             return origPath;


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11238
  - https://github.com/oracle/graal/commit/0b6bbf11f082ef7b3b43249d24844bbadc43d187

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
**Closes:** https://github.com/graalvm/graalvm-community-jdk21u/issues/121