### PR TITLE
[Backport] [Oracle GraalVM] [GR-63092] Backport to 23.1: Use dword comparisons in AMD64ArrayIndexOfOp because search values are definitely int

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64ArrayIndexOfOp.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64ArrayIndexOfOp.java
@@ -354,15 +354,15 @@ public final class AMD64ArrayIndexOfOp extends AMD64ComplexVectorOp {
             case MatchAny:
                 asm.movSZx(valueSize, ZERO_EXTEND, cmpResult, arrayAddr);
                 for (int i = 0; i < nValues; i++) {
-                    cmpqAndJcc(crb, asm, cmpResult, searchValue[i], elementWiseFound, ConditionFlag.Equal, true);
+                    cmplAndJcc(crb, asm, cmpResult, searchValue[i], elementWiseFound, ConditionFlag.Equal, true);
                 }
                 break;
             case MatchRange:
                 asm.movSZx(valueSize, ZERO_EXTEND, cmpResult, arrayAddr);
                 for (int i = 0; i < nValues; i += 2) {
                     Label noMatch = new Label();
-                    cmpqAndJcc(crb, asm, cmpResult, searchValue[i], noMatch, ConditionFlag.Below, true);
-                    cmpqAndJcc(crb, asm, cmpResult, searchValue[i + 1], elementWiseFound, ConditionFlag.BelowEqual, true);
+                    cmplAndJcc(crb, asm, cmpResult, searchValue[i], noMatch, ConditionFlag.Below, true);
+                    cmplAndJcc(crb, asm, cmpResult, searchValue[i + 1], elementWiseFound, ConditionFlag.BelowEqual, true);
                     asm.bind(noMatch);
                 }
                 break;
@@ -509,11 +509,11 @@ public final class AMD64ArrayIndexOfOp extends AMD64ComplexVectorOp {
         }
     }
 
-    private static void cmpqAndJcc(CompilationResultBuilder crb, AMD64MacroAssembler asm, Register src1, Value src2, Label branchTarget, ConditionFlag cc, boolean isShortJmp) {
+    private static void cmplAndJcc(CompilationResultBuilder crb, AMD64MacroAssembler asm, Register src1, Value src2, Label branchTarget, ConditionFlag cc, boolean isShortJmp) {
         if (isStackSlot(src2)) {
-            asm.cmpqAndJcc(src1, (AMD64Address) crb.asAddress(src2), cc, branchTarget, isShortJmp);
+            asm.cmplAndJcc(src1, (AMD64Address) crb.asAddress(src2), cc, branchTarget, isShortJmp);
         } else {
-            asm.cmpqAndJcc(src1, asRegister(src2), cc, branchTarget, isShortJmp);
+            asm.cmplAndJcc(src1, asRegister(src2), cc, branchTarget, isShortJmp);
         }
     }
 


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10869
- https://github.com/oracle/graal/commit/253bb4a6cd66b3bf4cf8a67a4f9a29ac1046f29b

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
**Closes:** https://github.com/graalvm/graalvm-community-jdk21u/issues/112
