### PR TITLE
[Backport] [Oracle GraalVM] [GR-64347] Backport to 23.1: TRegex: fix GenerateDFAImmediately option not freeing nfa matcher.

### DIFF
--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/nodes/TRegexExecNode.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/nodes/TRegexExecNode.java
@@ -102,6 +102,9 @@ public class TRegexExecNode extends RegexExecNode implements RegexProfile.Tracks
         this.runnerNode = insert(nfaNode);
         if (this.regressionTestMode || !backtrackingMode && ast.getOptions().isGenerateDFAImmediately()) {
             switchToLazyDFA();
+            if (!this.regressionTestMode) {
+                nfaNode = null;
+            }
         }
         if (this.regressionTestMode) {
             regressTestBacktrackingNode = new NFARegexSearchNode(


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/commit/19a54ab75cbf56214fdaacc6c3156b5733b8c443

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
**Closes:** https://github.com/graalvm/graalvm-community-jdk21u/issues/104