### PR TITLE
[Backport] [Oracle GraalVM] [GR-63455] Backport to 23.1: Remove pointless parallel stream processing for classpath entries.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageClassLoaderSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageClassLoaderSupport.java
@@ -625,7 +625,7 @@ public class NativeImageClassLoaderSupport {
                     initModule(moduleReference);
                 }
 
-                classpath().parallelStream().forEach(this::loadClassesFromPath);
+                classpath().forEach(this::loadClassesFromPath);
             } finally {
                 scheduledExecutor.shutdown();
             }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10920
  - https://github.com/oracle/graal/commit/8ecf1132b617721d9bf224191430fb31786b5f5f

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/102
