### PR TITLE
Simplify `Closes` clause to enable github to link issue to PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,4 @@
 **Conflicts:** There were no conflicts.
 
 <!-- Add the backport issue that this PR closes -->
-**Closes:** https://github.com/graalvm/graalvm-community-jdk21u/issues/
+Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/


### PR DESCRIPTION
The current format doesn't seem to be recognized by github, resulting in PRs not being linked to the corresponding issue, and thus automatically closing it once merged.