### PR TITLE
[Backport] [Oracle GraalVM] [GR-62969] Backport to 23.1: Fix return type compatibility check can lead to void specializations being filtered.

### DIFF
--- a/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/GR62540Test.java
+++ b/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/GR62540Test.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oracle.truffle.api.dsl.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateInline;
+import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.dsl.test.GR62540TestFactory.TestVoidSpecializationNodeGen;
+import com.oracle.truffle.api.nodes.Node;
+
+public class GR62540Test {
+
+    @Test
+    public void testFallthrough0() {
+        TestVoidSpecialization node = TestVoidSpecializationNodeGen.create();
+        node.execute(0);
+        node.execute(0); // not failing
+    }
+
+    abstract static class BaseNode extends Node {
+
+        abstract Object execute(int i);
+
+        void executeVoid(int i) {
+            execute(i);
+        }
+    }
+
+    @GenerateInline(false)
+    @SuppressWarnings("unused")
+    abstract static class TestVoidSpecialization extends BaseNode {
+
+        int cached = 1;
+
+        @NeverDefault
+        int incCached() {
+            return cached++;
+        }
+
+        @Specialization(guards = "i==0")
+        void s0(int i, @Cached("incCached()") int incCached) {
+            /*
+             * If cached is not 2 then executeAndSpecialize was called more than once.
+             */
+            assertEquals(2, cached);
+        }
+
+        @Specialization(guards = "i==1")
+        Object s1(int i) {
+            return null;
+        }
+
+    }
+
+}

--- a/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/FlatNodeGenFactory.java
+++ b/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/FlatNodeGenFactory.java
@@ -2682,15 +2682,20 @@ public class FlatNodeGenFactory {
                 }
             }
 
-            TypeMirror returnType = forType.getReturnType();
-            if (!isVoid(returnType) && !isSubtypeBoxed(context, specialization.getReturnType().getType(), returnType) &&
-                            !isSubtypeBoxed(context, returnType, specialization.getReturnType().getType())) {
-                continue outer;
+            TypeMirror executeReturnType = forType.getReturnType();
+            TypeMirror specializationReturnType = specialization.getReturnType().getType();
+            if (isReturnTypeCompatible(executeReturnType, specializationReturnType)) {
+                filteredSpecializations.add(specialization);
             }
-            filteredSpecializations.add(specialization);
         }
 
         return filteredSpecializations;
+    }
+
+    private boolean isReturnTypeCompatible(TypeMirror executeReturnType, TypeMirror specializationReturnType) {
+        return isVoid(executeReturnType) || isVoid(specializationReturnType) || //
+                        isSubtypeBoxed(context, specializationReturnType, executeReturnType) ||
+                        isSubtypeBoxed(context, executeReturnType, specializationReturnType);
     }
 
     private List<SpecializationData> filterImplementedSpecializations(List<SpecializationData> specializations, TypeMirror expectedReturnType) {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10779
  - https://github.com/oracle/graal/commit/4ff4aa89a7da5ed2e97739cec9b200f8a8af1516

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**

```java
<<<<<<< HEAD
            TypeMirror returnType = forType.getReturnType();
            if (!isVoid(returnType) && !isSubtypeBoxed(context, specialization.getReturnType().getType(), returnType) &&
                            !isSubtypeBoxed(context, returnType, specialization.getReturnType().getType())) {
                continue outer;
=======
            TypeMirror executeReturnType = forType.getReturnType();
            TypeMirror specializationReturnType = specialization.lookupBoxingOverloadReturnType(forType);
            if (isReturnTypeCompatible(executeReturnType, specializationReturnType)) {
                filteredSpecializations.add(specialization);
>>>>>>> 4ff4aa89a7d (Fix return type compatibility check can lead to void specializations being filtered.)
```
lookupBoxingOverloadReturnType was introduced in mainline change https://github.com/oracle/graal/commit/444204403252252a3f91243927c432aeb48cb074
resolution: use specialization.getReturnType().getType()

```java
<<<<<<< HEAD
    private List<SpecializationData> filterImplementedSpecializations(List<SpecializationData> specializations, TypeMirror expectedReturnType) {
=======
    private boolean isReturnTypeCompatible(TypeMirror executeReturnType, TypeMirror specializationReturnType) {
        return isVoid(executeReturnType) || isVoid(specializationReturnType) || //
                        isSubtypeBoxed(context, specializationReturnType, executeReturnType) ||
                        isSubtypeBoxed(context, executeReturnType, specializationReturnType);
    }

    private List<SpecializationData> filterImplementedSpecializations(List<SpecializationData> specializations, ExecutableTypeData forType) {
>>>>>>> 4ff4aa89a7d (Fix return type compatibility check can lead to void specializations being filtered.)
```
Accept both changes: new function and filterImplementedSpecializations with current signature

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/120
