### PR TITLE
[Backport] [Oracle GraalVM] [GR-63770] Backport to 23.1: Missing Truffle Safepoint poll in bytecode interpreter loop.

### DIFF
--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
@@ -96,6 +96,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.ExactMath;
 import com.oracle.truffle.api.HostCompilerDirectives.BytecodeInterpreterSwitch;
 import com.oracle.truffle.api.TruffleContext;
+import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.BytecodeOSRNode;
@@ -370,6 +371,7 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
                     break;
                 }
                 case Bytecode.LOOP: {
+                    TruffleSafepoint.poll(this);
                     if (CompilerDirectives.hasNextTier() && ++backEdgeCounter.count >= REPORT_LOOP_STRIDE) {
                         LoopNode.reportLoopCount(this, REPORT_LOOP_STRIDE);
                         backEdgeCounter.count = 0;


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/commit/7a6e19a38d8ab0f12a605aab6411438b6fd47e7c

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
Minor conflict:
```
<<<<<<< HEAD
import com.oracle.truffle.api.TruffleContext;
=======
import com.oracle.truffle.api.TruffleSafepoint;
>>>>>>> 7a6e19a38d8 (Add missing Truffle Safepoint poll in Wasm interpreter loop.)
```
resolution: accept both imports as they both are used in a class


<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/103