### PR TITLE
[Backport] [Oracle GraalVM] [GR-63403] Backport to 23.1: Don't assume that partitions with offset 0 are fillers.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ChunkedImageHeapAllocator.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ChunkedImageHeapAllocator.java
@@ -288,4 +288,9 @@ final class FillerObjectDummyPartition implements ImageHeapPartition {
     public long getSize() {
         throw VMError.shouldNotReachHereAtRuntime(); // ExcludeFromJacocoGeneratedReport
     }
+
+    @Override
+    public boolean isFiller() {
+        return true;
+    }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ChunkedImageHeapPartition.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ChunkedImageHeapPartition.java
@@ -186,6 +186,11 @@ public class ChunkedImageHeapPartition extends AbstractImageHeapPartition {
         return getEndOffset() - getStartOffset();
     }
 
+    @Override
+    public boolean isFiller() {
+        return false;
+    }
+
     private static class SizeComparator implements Comparator<ImageHeapObject> {
         @Override
         public int compare(ImageHeapObject o1, ImageHeapObject o2) {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LinearImageHeapPartition.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LinearImageHeapPartition.java
@@ -84,4 +84,9 @@ public class LinearImageHeapPartition extends AbstractImageHeapPartition {
     public long getSize() {
         return getEndOffset() - getStartOffset();
     }
+
+    @Override
+    public boolean isFiller() {
+        return false;
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/image/ImageHeapPartition.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/image/ImageHeapPartition.java
@@ -39,4 +39,7 @@ public interface ImageHeapPartition {
      * Returns the size of the partition (i.e., the sum of all allocated objects + some overhead).
      */
     long getSize();
+
+    /* Returns true if this partition is only used as a filler. */
+    boolean isFiller();
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -2700,7 +2700,7 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
 
     private boolean acceptObjectInfo(ObjectInfo objectInfo) {
         /* This condition rejects filler partition objects. */
-        return (objectInfo.getPartition().getStartOffset() > 0);
+        return !objectInfo.getPartition().isFiller();
     }
 
     private DebugDataInfo createDebugDataInfo(ObjectInfo objectInfo) {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10894
  - https://github.com/oracle/graal/commit/a9bbe92ec669adb1620152922209108637fd0bf5

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 

```java
<<<<<<< HEAD
import org.graalvm.compiler.core.common.NumUtil;
=======
>>>>>>> a9bbe92ec66 (Don't assume that partitions with offset 0 are fillers.)
<<<<<<< HEAD
    private static class SizeComparator implements Comparator<ImageHeapObject> {
=======
    @Override
    public boolean isFiller() {
        return false;
    }

    @Override
    public String toString() {
        return name;
    }

    private static final class SizeComparator implements Comparator<ImageHeapObject> {
>>>>>>> a9bbe92ec66 (Don't assume that partitions with offset 0 are fillers.)
```
collision due to missing toString method and SizeComparator is not final on graal-jdk21 version 
resolution: just add isFiller method

```java
<<<<<<< HEAD
=======
/**
 * A pseudo-partition necessary for {@link ImageHeapObject}s that refer to base layer constants,
 * i.e., they are not actually written in current layer's heap. Their offset is absolute (not
 * relative to a partition start offset) and is serialized from the base layer.
 */
final class BaseLayerPartition implements ImageHeapPartition {
    /** Zero so that the partition-relative offsets are always absolute. */
    @Override
    public long getStartOffset() {
        return 0;
    }

    @Override
    public String getName() {
        throw VMError.shouldNotReachHereAtRuntime(); // ExcludeFromJacocoGeneratedReport
    }

    @Override
    public long getSize() {
        throw VMError.shouldNotReachHereAtRuntime(); // ExcludeFromJacocoGeneratedReport
    }

    @Override
    public boolean isFiller() {
        return false;
    }
}
>>>>>>> a9bbe92ec66 (Don't assume that partitions with offset 0 are fillers.)
```
NativeImageHeap.BaseLayerPartition class exist on mainline since 4c3a03816bdcc3239adf054deeb21585d413aee2 - there is no corresponding class on graalvm-jdk21 version. Skipped. Though, need to add isFiller method to LinearImageHeapPartition class which extends AbstractImageHeapPartition and needs the implementation (the class does not exist in the mainline)

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/110