### PR TITLE
[Backport] [Oracle GraalVM] [GR-63484] Backport to 23.1: AMD64ArrayIndexOfOp: Fix short jump across unknown alignment.

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64ArrayIndexOfOp.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64ArrayIndexOfOp.java
@@ -433,8 +433,12 @@ public final class AMD64ArrayIndexOfOp extends AMD64ComplexVectorOp {
         asm.addq(index, bulkSize);
 
         boolean bulkLoopShortJmp = !((variant == ArrayIndexOfVariant.MatchRange && nValues == 4 || variant == ArrayIndexOfVariant.Table) && stride.value > 1);
-        // check if there are enough array slots remaining for the bulk loop
-        asm.cmpqAndJcc(index, arrayLength, ConditionFlag.Greater, skipBulkVectorLoop, bulkLoopShortJmp);
+        /*
+         * Check if there are enough array slots remaining for the bulk loop. Note: The alignment
+         * following the cmpAndJcc can lead to a jump distance > 127. This prevents safely using a
+         * short jump.
+         */
+        asm.cmpqAndJcc(index, arrayLength, ConditionFlag.Greater, skipBulkVectorLoop, false);
 
         asm.align(preferredLoopAlignment(crb));
         asm.bind(bulkVectorLoop);


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10916
  - https://github.com/oracle/graal/commit/15877a2cfffc1c8c56a13842cf9d6b73a8257e21
 
<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**

<details>

```java
<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64ArrayIndexOfOp.java
import static org.graalvm.compiler.asm.amd64.AMD64MacroAssembler.ExtendMode.ZERO_EXTEND;
import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.ILLEGAL;
import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.REG;
import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.STACK;

import java.util.EnumSet;

import org.graalvm.compiler.asm.Label;
import org.graalvm.compiler.asm.amd64.AMD64Address;
import org.graalvm.compiler.asm.amd64.AMD64Assembler;
import org.graalvm.compiler.asm.amd64.AMD64Assembler.ConditionFlag;
import org.graalvm.compiler.asm.amd64.AMD64Assembler.VexMoveOp;
import org.graalvm.compiler.asm.amd64.AMD64Assembler.VexRMIOp;
import org.graalvm.compiler.asm.amd64.AMD64Assembler.VexRMOp;
import org.graalvm.compiler.asm.amd64.AMD64Assembler.VexRVMOp;
import org.graalvm.compiler.asm.amd64.AMD64BaseAssembler.OperandSize;
import org.graalvm.compiler.asm.amd64.AMD64MacroAssembler;
import org.graalvm.compiler.asm.amd64.AVXKind.AVXSize;
import org.graalvm.compiler.core.common.Stride;
import org.graalvm.compiler.debug.GraalError;
import org.graalvm.compiler.lir.ConstantValue;
import org.graalvm.compiler.lir.LIRInstructionClass;
import org.graalvm.compiler.lir.Opcode;
import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
import org.graalvm.compiler.lir.gen.LIRGeneratorTool.ArrayIndexOfVariant;

=======

import java.util.EnumSet;

import jdk.graal.compiler.asm.Label;
import jdk.graal.compiler.asm.amd64.AMD64Address;
import jdk.graal.compiler.asm.amd64.AMD64Assembler;
import jdk.graal.compiler.asm.amd64.AMD64Assembler.ConditionFlag;
import jdk.graal.compiler.asm.amd64.AMD64Assembler.VexMoveOp;
import jdk.graal.compiler.asm.amd64.AMD64Assembler.VexRMIOp;
import jdk.graal.compiler.asm.amd64.AMD64Assembler.VexRMOp;
import jdk.graal.compiler.asm.amd64.AMD64Assembler.VexRVMOp;
import jdk.graal.compiler.asm.amd64.AMD64BaseAssembler.OperandSize;
import jdk.graal.compiler.asm.amd64.AMD64MacroAssembler;
import jdk.graal.compiler.asm.amd64.AVXKind.AVXSize;
import jdk.graal.compiler.core.common.Stride;
import jdk.graal.compiler.debug.Assertions;
import jdk.graal.compiler.debug.GraalError;
import jdk.graal.compiler.lir.ConstantValue;
import jdk.graal.compiler.lir.LIRInstructionClass;
import jdk.graal.compiler.lir.Opcode;
import jdk.graal.compiler.lir.asm.CompilationResultBuilder;
import jdk.graal.compiler.lir.gen.LIRGeneratorTool;
>>>>>>> 15877a2cfff (AMD64ArrayIndexOfOp: Fix short jump across unknown alignment.):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/lir/amd64/AMD64ArrayIndexOfOp.java
```
minor class names issue
resolution: accept the local version.

```java
<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64ArrayIndexOfOp.java
        boolean bulkLoopShortJmp = !((variant == ArrayIndexOfVariant.MatchRange && nValues == 4 || variant == ArrayIndexOfVariant.Table) && stride.value > 1);
        // check if there are enough array slots remaining for the bulk loop
        asm.cmpqAndJcc(index, arrayLength, ConditionFlag.Greater, skipBulkVectorLoop, bulkLoopShortJmp);
=======
        boolean bulkLoopShortJmp = !((variant == LIRGeneratorTool.ArrayIndexOfVariant.MatchRange && nValues == 4 || variant == LIRGeneratorTool.ArrayIndexOfVariant.Table) && stride.value > 1);
        /*
         * Check if there are enough array slots remaining for the bulk loop. Note: The alignment
         * following the cmpAndJcc can lead to a jump distance > 127. This prevents safely using a
         * short jump.
         */
        asm.cmpqAndJcc(index, arrayLength, ConditionFlag.Greater, skipBulkVectorLoop, false);
>>>>>>> 15877a2cfff (AMD64ArrayIndexOfOp: Fix short jump across unknown alignment.):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/lir/amd64/AMD64ArrayIndexOfOp.java
```
bulkLoopShortJmp is calculated differently on mainline and jdk21 version
resolution: leave bulkLoopShortJmp calculation as is, but pass false to asm.cmpqAndJcc

</details>

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/109
