### PR TITLE
[Backport] [Oracle GraalVM] [GR-63567] Backport to 23.1: Process each class' classloader in JfrTypeRepository

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -104,6 +104,7 @@ public class JfrTypeRepository implements JfrRepository {
 
     private void visitClass(TypeInfo typeInfo, Class<?> clazz) {
         if (clazz != null && addClass(typeInfo, clazz)) {
+            visitClassLoader(typeInfo, clazz.getClassLoader());
             visitPackage(typeInfo, clazz.getPackage(), clazz.getModule());
             visitClass(typeInfo, clazz.getSuperclass());
         }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10749
  - https://github.com/oracle/graal/commit/2a8e70d86505f834e81bbc5a6551e572b5455841
 
<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/74

**Note:** that https://github.com/graalvm/graalvm-community-jdk21u/issues/74 mentions GR-63567 and https://github.com/oracle/graal/commit/62b16a368fe5004d7b812b8d9550aa0a905e78d2 which are not publicly accessible.