### PR TITLE
[Backport] [Oracle GraalVM] [GR-63571] Backport to 23.1: Fix class names in heap dumps.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpWriter.java
@@ -76,6 +76,8 @@ import com.oracle.svm.core.heap.dump.HeapDumpMetadata.FieldName;
 import com.oracle.svm.core.heap.dump.HeapDumpMetadata.FieldNameAccess;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.hub.LayoutEncoding;
+import com.oracle.svm.core.jdk.UninterruptibleUtils.CharReplacer;
+import com.oracle.svm.core.jdk.UninterruptibleUtils.ReplaceDotWithSlash;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.os.BufferedFileOperationSupport;
 import com.oracle.svm.core.os.BufferedFileOperationSupport.BufferedFile;
@@ -396,6 +398,7 @@ public class HeapDumpWriter {
     private static final int HEAP_DUMP_SEGMENT_TARGET_SIZE = 1 * 1024 * 1024;
 
     private final NoAllocationVerifier noAllocationVerifier = NoAllocationVerifier.factory("HeapDumpWriter", false);
+    private final ReplaceDotWithSlash dotWithSlashReplacer = new ReplaceDotWithSlash();
     private final DumpStackFrameVisitor dumpStackFrameVisitor = new DumpStackFrameVisitor();
     private final DumpObjectsVisitor dumpObjectsVisitor = new DumpObjectsVisitor();
     private final CodeMetadataVisitor codeMetadataVisitor = new CodeMetadataVisitor();
@@ -543,15 +546,19 @@ public class HeapDumpWriter {
         for (int i = 0; i < metadata.getClassInfoCount(); i++) {
             ClassInfo classInfo = metadata.getClassInfo(i);
             if (ClassInfoAccess.isValid(classInfo)) {
-                writeSymbol(classInfo.getHub().getName());
+                writeSymbol(classInfo.getHub().getName(), dotWithSlashReplacer);
             }
         }
     }
 
     private void writeSymbol(String value) {
+        writeSymbol(value, null);
+    }
+
+    private void writeSymbol(String value, CharReplacer replacer) {
         startTopLevelRecord(HProfTopLevelRecord.UTF8);
         writeObjectId(value);
-        writeUTF8(value);
+        writeUTF8(value, replacer);
         endTopLevelRecord();
     }
 
@@ -1107,7 +1114,11 @@ public class HeapDumpWriter {
     }
 
     private void writeUTF8(String value) {
-        boolean success = file().writeUTF8(f, value);
+        writeUTF8(value, null);
+    }
+
+    private void writeUTF8(String value, CharReplacer replacer) {
+        boolean success = file().writeUTF8(f, value, replacer);
         handleError(success);
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
@@ -41,6 +41,7 @@ import com.oracle.svm.core.collections.UninterruptibleEntry;
 import com.oracle.svm.core.heap.Heap;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.jdk.UninterruptibleUtils.CharReplacer;
+import com.oracle.svm.core.jdk.UninterruptibleUtils.ReplaceDotWithSlash;
 import com.oracle.svm.core.jfr.traceid.JfrTraceIdEpoch;
 import com.oracle.svm.core.locks.VMMutex;
 
@@ -236,17 +237,6 @@ public class JfrSymbolRepository implements JfrRepository {
             unflushedEntries = 0;
             JfrBufferAccess.free(buffer);
             buffer = WordFactory.nullPointer();
-        }
-    }
-
-    private static class ReplaceDotWithSlash implements CharReplacer {
-        @Override
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        public char replace(char ch) {
-            if (ch == '.') {
-                return '/';
-            }
-            return ch;
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/BufferedFileOperationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/BufferedFileOperationSupport.java
@@ -46,7 +46,8 @@ import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.hub.LayoutEncoding;
-import com.oracle.svm.core.jdk.JavaLangSubstitutions;
+import com.oracle.svm.core.jdk.UninterruptibleUtils;
+import com.oracle.svm.core.jdk.UninterruptibleUtils.CharReplacer;
 import com.oracle.svm.core.os.BufferedFileOperationSupport.BufferedFileOperationSupportHolder;
 import com.oracle.svm.core.os.RawFileOperationSupport.RawFileDescriptor;
 import com.oracle.svm.core.snippets.KnownIntrinsics;
@@ -342,6 +343,11 @@ public class BufferedFileOperationSupport {
         return writeLong(f, Double.doubleToLongBits(v));
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean writeUTF8(BufferedFile f, String string) {
+        return writeUTF8(f, string, null);
+    }
+
     /**
      * Writes the String characters encoded as UTF8 to the current file position and advances the
      * file position.
@@ -349,10 +355,14 @@ public class BufferedFileOperationSupport {
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean writeUTF8(BufferedFile f, String string) {
+    public boolean writeUTF8(BufferedFile f, String string, CharReplacer replacer) {
         boolean success = true;
         for (int index = 0; index < string.length() && success; index++) {
-            success &= writeUTF8(f, JavaLangSubstitutions.StringUtil.charAt(string, index));
+            char ch = UninterruptibleUtils.String.charAt(string, index);
+            if (replacer != null) {
+                ch = replacer.replace(ch);
+            }
+            success &= writeUTF8(f, ch);
         }
         return success;
     }


### PR DESCRIPTION
<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**
- https://github.com/oracle/graal/pull/10931

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
There were conflicts in the following files:
* `substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpWriter.java`
* `substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/UninterruptibleUtils.java`
* `substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java`
* `substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/BufferedFileOperationSupport.java`

I ended up doing the backport manually, as I needed to add code in a previous commit, specifically the `charAt` method in `substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/UninterruptibleUtils.java`.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/111
