### PR TITLE
[Backport] [Oracle GraalVM] [GR-62941] Backport to 23.1: Memory barrier after Object.clone() is missing.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/jdk/SubstrateObjectCloneSnippets.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/jdk/SubstrateObjectCloneSnippets.java
@@ -41,6 +41,7 @@ import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.extended.BranchProbabilityNode;
 import org.graalvm.compiler.nodes.extended.ForeignCallNode;
+import org.graalvm.compiler.nodes.extended.MembarNode;
 import org.graalvm.compiler.nodes.java.ArrayLengthNode;
 import org.graalvm.compiler.nodes.spi.LoweringTool;
 import org.graalvm.compiler.nodes.spi.VirtualizerTool;
@@ -169,6 +170,12 @@ public final class SubstrateObjectCloneSnippets extends SubstrateTemplates imple
         if (monitorOffset != 0) {
             BarrieredAccess.writeObject(result, monitorOffset, null);
         }
+
+        /*
+         * Emit a STORE_STORE barrier to ensure that other threads see consistent values for final
+         * fields and VM internal fields.
+         */
+        MembarNode.memoryBarrier(MembarNode.FenceKind.STORE_STORE);
 
         return result;
     }


### PR DESCRIPTION
**This PR backports:**
- Part of https://github.com/oracle/graal/pull/10835 
  - https://github.com/oracle/graal/commit/7eab68b6200d6f4995c30dc26d6c3570760baccf
(A simple but crucial change — concurrent reads of uninitialized memory have never been safe)

Complements https://github.com/graalvm/graalvm-community-jdk21u/pull/131

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** Import packet names collision and minor doClone method disparity due to subsequent change on mainline: https://github.com/oracle/graal/commit/c24f5970307751aa1a93f241bdc14052a3d42109

<details>

```
<<<<<<< HEAD
import org.graalvm.compiler.api.replacements.Snippet;
import org.graalvm.compiler.core.common.NumUtil;
import org.graalvm.compiler.core.common.spi.ForeignCallDescriptor;
import org.graalvm.compiler.graph.Node;
import org.graalvm.compiler.graph.Node.ConstantNodeParameter;
import org.graalvm.compiler.graph.Node.NodeIntrinsic;
import org.graalvm.compiler.nodes.GraphState;
import org.graalvm.compiler.nodes.NodeView;
import org.graalvm.compiler.nodes.StructuredGraph;
import org.graalvm.compiler.nodes.ValueNode;
import org.graalvm.compiler.nodes.extended.BranchProbabilityNode;
import org.graalvm.compiler.nodes.extended.ForeignCallNode;
import org.graalvm.compiler.nodes.java.ArrayLengthNode;
import org.graalvm.compiler.nodes.spi.LoweringTool;
import org.graalvm.compiler.nodes.spi.VirtualizerTool;
import org.graalvm.compiler.nodes.virtual.VirtualObjectNode;
import org.graalvm.compiler.options.OptionValues;
import org.graalvm.compiler.phases.util.Providers;
import org.graalvm.compiler.replacements.SnippetTemplate;
import org.graalvm.compiler.replacements.SnippetTemplate.Arguments;
import org.graalvm.compiler.replacements.SnippetTemplate.SnippetInfo;
import org.graalvm.compiler.replacements.Snippets;
import org.graalvm.compiler.replacements.nodes.ObjectClone;
import org.graalvm.compiler.word.BarrieredAccess;
=======
>>>>>>> 7eab68b6200 (Add STORE_STORE barrier after Object.clone().)
<<<<<<< HEAD
import jdk.internal.misc.Unsafe;
=======
import jdk.graal.compiler.api.replacements.Snippet;
import jdk.graal.compiler.core.common.NumUtil;
import jdk.graal.compiler.core.common.spi.ForeignCallDescriptor;
import jdk.graal.compiler.graph.Node;
import jdk.graal.compiler.graph.Node.ConstantNodeParameter;
import jdk.graal.compiler.graph.Node.NodeIntrinsic;
import jdk.graal.compiler.nodes.NodeView;
import jdk.graal.compiler.nodes.StructuredGraph;
import jdk.graal.compiler.nodes.ValueNode;
import jdk.graal.compiler.nodes.extended.BranchProbabilityNode;
import jdk.graal.compiler.nodes.extended.ForeignCallNode;
import jdk.graal.compiler.nodes.extended.ForeignCallWithExceptionNode;
import jdk.graal.compiler.nodes.extended.MembarNode;
import jdk.graal.compiler.nodes.java.ArrayLengthNode;
import jdk.graal.compiler.nodes.spi.LoweringTool;
import jdk.graal.compiler.nodes.spi.VirtualizerTool;
import jdk.graal.compiler.nodes.virtual.VirtualObjectNode;
import jdk.graal.compiler.options.OptionValues;
import jdk.graal.compiler.phases.util.Providers;
import jdk.graal.compiler.replacements.SnippetTemplate;
import jdk.graal.compiler.replacements.SnippetTemplate.Arguments;
import jdk.graal.compiler.replacements.SnippetTemplate.SnippetInfo;
import jdk.graal.compiler.replacements.Snippets;
import jdk.graal.compiler.replacements.nodes.ObjectClone;
import jdk.graal.compiler.word.BarrieredAccess;
import jdk.graal.compiler.word.ObjectAccess;
import jdk.graal.compiler.word.Word;
>>>>>>> 7eab68b6200 (Add STORE_STORE barrier after Object.clone().)
<<<<<<< HEAD
=======
        /* Reset identity hashcode if it is potentially outside the object header. */
        if (ConfigurationValues.getObjectLayout().isIdentityHashFieldAtTypeSpecificOffset()) {
            int offset = LayoutEncoding.getIdentityHashOffset(result);
            ObjectAccess.writeInt(result, offset, 0);
        }

        /*
         * Emit a STORE_STORE barrier to ensure that other threads see consistent values for final
         * fields and VM internal fields.
         */
        MembarNode.memoryBarrier(MembarNode.FenceKind.STORE_STORE);

>>>>>>> 7eab68b6200 (Add STORE_STORE barrier after Object.clone().)
```
</details>

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/108
