### PR TITLE
Fix JFR-related UnsatisfiedLinkErrors.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VMInspectionOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VMInspectionOptions.java
@@ -93,6 +93,12 @@ public final class VMInspectionOptions {
         return SubstrateOptionsParser.commandArgument(EnableMonitoringFeatures, MONITORING_HEAPDUMP_NAME);
     }
 
+    @Fold
+    public static String getJfrNotSupportedMessage() {
+        return "JFR is only supported on Linux and MacOS for native binaries built with '" +
+                        SubstrateOptionsParser.commandArgument(EnableMonitoringFeatures, MONITORING_JFR_NAME) + "'.";
+    }
+
     private static Set<String> getEnabledMonitoringFeatures() {
         return new HashSet<>(EnableMonitoringFeatures.getValue().values());
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrJavaEvents.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrJavaEvents.java
@@ -35,22 +35,13 @@ import org.graalvm.nativeimage.Platforms;
  */
 public class JfrJavaEvents {
     private static final List<Class<? extends jdk.internal.event.Event>> EVENT_CLASSES = new ArrayList<>();
-    private static final List<Class<? extends jdk.jfr.Event>> JFR_EVENT_CLASSES = new ArrayList<>();
 
     @Platforms(Platform.HOSTED_ONLY.class)
-    @SuppressWarnings("unchecked")
     public static synchronized void registerEventClass(Class<? extends jdk.internal.event.Event> eventClass) {
         EVENT_CLASSES.add(eventClass);
-        if (jdk.jfr.Event.class.isAssignableFrom(eventClass)) {
-            JFR_EVENT_CLASSES.add((Class<? extends jdk.jfr.Event>) eventClass);
-        }
     }
 
     public static List<Class<? extends jdk.internal.event.Event>> getAllEventClasses() {
         return EVENT_CLASSES;
-    }
-
-    public static List<Class<? extends jdk.jfr.Event>> getJfrEventClasses() {
-        return JFR_EVENT_CLASSES;
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrJdkCompatibility.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrJdkCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,19 +24,24 @@
  */
 package com.oracle.svm.core.jfr;
 
+import org.graalvm.nativeimage.hosted.FieldValueTransformer;
+
 import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "jdk.jfr.internal.event.EventWriter")
-public final class Target_jdk_jfr_internal_event_EventWriter {
+@TargetClass(className = "jdk.jfr.internal.JVMSupport")
+final class Target_jdk_jfr_internal_JVMSupport {
     @Alias //
-    boolean excluded;
+    @RecomputeFieldValue(kind = Kind.Custom, declClass = JfrNotAvailableTransformer.class, isFinal = true) //
+    private static boolean notAvailable;
 
-    @Alias //
-    long threadID;
+}
 
-    @Alias
-    @SuppressWarnings("unused")
-    Target_jdk_jfr_internal_event_EventWriter(long committedPos, long maxPos, long threadID, boolean valid, boolean excluded) {
+final class JfrNotAvailableTransformer implements FieldValueTransformer {
+    @Override
+    public Object transform(Object receiver, Object originalValue) {
+        return !HasJfrSupport.get();
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrRecorderThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrRecorderThread.java
@@ -151,18 +151,10 @@ public class JfrRecorderThread extends Thread {
         }
 
         if (chunkWriter.shouldRotateDisk()) {
-            Object chunkRotationMonitor = getChunkRotationMonitor();
+            Object chunkRotationMonitor = Target_jdk_jfr_internal_JVM.CHUNK_ROTATION_MONITOR;
             synchronized (chunkRotationMonitor) {
                 chunkRotationMonitor.notifyAll();
             }
-        }
-    }
-
-    private static Object getChunkRotationMonitor() {
-        if (HasChunkRotationMonitorField.get()) {
-            return Target_jdk_jfr_internal_JVM.CHUNK_ROTATION_MONITOR;
-        } else {
-            return Target_jdk_jfr_internal_JVM.FILE_DELTA_CHANGE;
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -24,38 +24,37 @@
  */
 package com.oracle.svm.core.jfr;
 
-import java.util.List;
-import java.util.function.BooleanSupplier;
+import static com.oracle.svm.core.jfr.Target_jdk_jfr_internal_JVM_Util.jfrNotSupportedException;
 
-import org.graalvm.compiler.api.replacements.Fold;
-import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.Platforms;
+import java.util.List;
+
+// import org.graalvm.compiler.api.replacements.Fold;
+// import org.graalvm.nativeimage.Platform;
+// import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.ProcessProperties;
 
 import com.oracle.svm.core.Containers;
 import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.VMInspectionOptions;
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.annotate.TargetElement;
 import com.oracle.svm.core.jfr.traceid.JfrTraceId;
-import com.oracle.svm.util.ReflectionUtil;
 
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.LogTag;
 
+/**
+ * The substitutions below are always active, even if the JFR support is disabled. Otherwise, we
+ * would see an {@link UnsatisfiedLinkError} if a JFR native method is called at run-time.
+ */
 @SuppressWarnings({"static-method", "unused"})
-@TargetClass(value = jdk.jfr.internal.JVM.class, onlyWith = HasJfrSupport.class)
+@TargetClass(value = jdk.jfr.internal.JVM.class)
 public final class Target_jdk_jfr_internal_JVM {
     // Checkstyle: stop
     @Alias //
-    @TargetElement(onlyWith = HasChunkRotationMonitorField.class) //
     static Object CHUNK_ROTATION_MONITOR;
-
-    @Alias //
-    @TargetElement(onlyWith = HasFileDeltaChangeField.class) //
-    static Object FILE_DELTA_CHANGE;
     // Checkstyle: resume
 
     @Alias //
@@ -67,14 +66,21 @@ public final class Target_jdk_jfr_internal_JVM {
     private static void registerNatives() {
     }
 
+    /** See {@link JVM#markChunkFinal}. */
     @Substitute
     public void markChunkFinal() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().markChunkFinal();
     }
 
     /** See {@link JVM#beginRecording}. */
     @Substitute
     public void beginRecording() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().beginRecording();
     }
 
@@ -82,12 +88,19 @@ public final class Target_jdk_jfr_internal_JVM {
     @Substitute
     @Uninterruptible(reason = "Needed for calling SubstrateJVM.isRecording().")
     public boolean isRecording() {
+        if (!HasJfrSupport.get()) {
+            return false;
+        }
         return SubstrateJVM.get().isRecording();
     }
 
     /** See {@link JVM#endRecording}. */
     @Substitute
     public void endRecording() {
+        if (!HasJfrSupport.get()) {
+            /* Nothing to do. */
+            return;
+        }
         SubstrateJVM.get().endRecording();
     }
 
@@ -119,6 +132,10 @@ public final class Target_jdk_jfr_internal_JVM {
     @Substitute
     @Uninterruptible(reason = "Needed for SubstrateJVM.getClassId().")
     public static long getClassId(Class<?> clazz) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
+
         /*
          * The result is only valid until the epoch changes but this is fine because EventWriter
          * instances are invalidated when the epoch changes.
@@ -137,6 +154,10 @@ public final class Target_jdk_jfr_internal_JVM {
     @Substitute
     @Uninterruptible(reason = "Needed for SubstrateJVM.getStackTraceId().")
     public long getStackTraceId(int skipCount) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
+
         /*
          * The result is only valid until the epoch changes but this is fine because EventWriter
          * instances are invalidated when the epoch changes.
@@ -147,6 +168,9 @@ public final class Target_jdk_jfr_internal_JVM {
     /** See {@link JVM#getThreadId}. */
     @Substitute
     public long getThreadId(Thread t) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.getThreadId(t);
     }
 
@@ -159,18 +183,27 @@ public final class Target_jdk_jfr_internal_JVM {
     /** See {@link JVM#log}. */
     @Substitute
     public static void log(int tagSetId, int level, String message) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().log(tagSetId, level, message);
     }
 
     /** See {@link JVM#logEvent}. */
     @Substitute
     public static void logEvent(int level, String[] lines, boolean system) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().logEvent(level, lines, system);
     }
 
     /** See {@link JVM#subscribeLogLevel}. */
     @Substitute
     public static void subscribeLogLevel(LogTag lt, int tagSetId) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().subscribeLogLevel(lt, tagSetId);
     }
 
@@ -183,42 +216,63 @@ public final class Target_jdk_jfr_internal_JVM {
     /** See {@link JVM#setEnabled}. */
     @Substitute
     public void setEnabled(long eventTypeId, boolean enabled) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setEnabled(eventTypeId, enabled);
     }
 
     /** See {@link JVM#setFileNotification}. */
     @Substitute
     public void setFileNotification(long delta) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setFileNotification(delta);
     }
 
     /** See {@link JVM#setGlobalBufferCount}. */
     @Substitute
     public void setGlobalBufferCount(long count) throws IllegalArgumentException, IllegalStateException {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setGlobalBufferCount(count);
     }
 
     /** See {@link JVM#setGlobalBufferSize}. */
     @Substitute
     public void setGlobalBufferSize(long size) throws IllegalArgumentException {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setGlobalBufferSize(size);
     }
 
     /** See {@link JVM#setMemorySize}. */
     @Substitute
     public void setMemorySize(long size) throws IllegalArgumentException {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setMemorySize(size);
     }
 
     /** See {@code JVM#setMethodSamplingPeriod}. */
     @Substitute
     public void setMethodSamplingPeriod(long type, long intervalMillis) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setMethodSamplingInterval(type, intervalMillis);
     }
 
     /** See {@link JVM#setOutput}. */
     @Substitute
     public void setOutput(String file) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setOutput(file);
     }
 
@@ -230,36 +284,54 @@ public final class Target_jdk_jfr_internal_JVM {
     /** See {@link JVM#setCompressedIntegers}. */
     @Substitute
     public void setCompressedIntegers(boolean compressed) throws IllegalStateException {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setCompressedIntegers(compressed);
     }
 
     /** See {@link JVM#setStackDepth}. */
     @Substitute
     public void setStackDepth(int depth) throws IllegalArgumentException, IllegalStateException {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setStackDepth(depth);
     }
 
     /** See {@link JVM#setStackTraceEnabled}. */
     @Substitute
     public void setStackTraceEnabled(long eventTypeId, boolean enabled) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setStackTraceEnabled(eventTypeId, enabled);
     }
 
     /** See {@link JVM#setThreadBufferSize}. */
     @Substitute
     public void setThreadBufferSize(long size) throws IllegalArgumentException, IllegalStateException {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setThreadBufferSize(size);
     }
 
     /** See {@link JVM#setThreshold}. */
     @Substitute
     public boolean setThreshold(long eventTypeId, long ticks) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().setThreshold(eventTypeId, ticks);
     }
 
     /** See {@link JVM#storeMetadataDescriptor}. */
     @Substitute
     public void storeMetadataDescriptor(byte[] bytes) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().storeMetadataDescriptor(bytes);
     }
 
@@ -272,19 +344,25 @@ public final class Target_jdk_jfr_internal_JVM {
     /** See {@link JVM#createJFR}. */
     @Substitute
     private boolean createJFR(boolean simulateFailure) throws IllegalStateException {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().createJFR(simulateFailure);
     }
 
     /** See {@link JVM#destroyJFR}. */
     @Substitute
     private boolean destroyJFR() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().destroyJFR();
     }
 
     /** See {@link JVM#isAvailable}. */
     @Substitute
     public boolean isAvailable() {
-        return true;
+        return HasJfrSupport.get();
     }
 
     /** See {@link JVM#getTimeConversionFactor}. */
@@ -296,58 +374,90 @@ public final class Target_jdk_jfr_internal_JVM {
     /** See {@link JVM#getTypeId(Class)}. */
     @Substitute
     public long getTypeId(Class<?> clazz) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return JfrTraceId.getTraceId(clazz);
     }
 
     /** See {@link JVM#getEventWriter}. */
     @Substitute
     public static Object getEventWriter() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().getEventWriter();
     }
 
     /** See {@link JVM#newEventWriter}. */
     @Substitute
     public static Target_jdk_jfr_internal_event_EventWriter newEventWriter() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().newEventWriter();
     }
 
     /** See {@link JVM#flush}. */
     @Substitute
     public static void flush(Target_jdk_jfr_internal_event_EventWriter writer, int uncommittedSize, int requestedSize) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().flush(writer, uncommittedSize, requestedSize);
     }
 
+    /** See {@link JVM#flush()}. */
     @Substitute
     public void flush() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().flush();
     }
 
+    /** See {@link JVM#commit}. */
     @Substitute
     public static long commit(long nextPosition) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().commit(nextPosition);
     }
 
     /** See {@link JVM#setRepositoryLocation}. */
     @Substitute
     public void setRepositoryLocation(String dirText) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setRepositoryLocation(dirText);
     }
 
     /** See {@code JVM#setDumpPath(String)}. */
     @Substitute
     public void setDumpPath(String dumpPathText) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().setDumpPath(dumpPathText);
     }
 
     /** See {@code JVM#getDumpPath()}. */
     @Substitute
     public String getDumpPath() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().getDumpPath();
     }
 
     /** See {@link JVM#abort}. */
     @Substitute
     public void abort(String errorMsg) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         SubstrateJVM.get().abort(errorMsg);
     }
 
@@ -367,12 +477,18 @@ public final class Target_jdk_jfr_internal_JVM {
     /** See {@link JVM#setCutoff}. */
     @Substitute
     public boolean setCutoff(long eventTypeId, long cutoffTicks) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().setCutoff(eventTypeId, cutoffTicks);
     }
 
     @Substitute
     public boolean setThrottle(long eventTypeId, long eventSampleSize, long periodMs) {
         // Not supported but this method is called during JFR startup, so we can't throw an error.
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return true;
     }
 
@@ -380,54 +496,88 @@ public final class Target_jdk_jfr_internal_JVM {
     @Substitute
     public void emitOldObjectSamples(long cutoff, boolean emitAll, boolean skipBFS) {
         // Not supported but this method is called during JFR shutdown, so we can't throw an error.
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
     }
 
     /** See {@link JVM#shouldRotateDisk}. */
     @Substitute
     public boolean shouldRotateDisk() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().shouldRotateDisk();
     }
 
+    /** See {@link JVM#include}. */
     @Substitute
     public void include(Thread thread) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         JfrThreadLocal.setExcluded(thread, false);
     }
 
+    /** See {@link JVM#exclude}. */
     @Substitute
     public void exclude(Thread thread) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         JfrThreadLocal.setExcluded(thread, true);
     }
 
+    /** See {@link JVM#isExcluded(Thread)}. */
     @Substitute
     public boolean isExcluded(Thread thread) {
+        if (!HasJfrSupport.get()) {
+            return true;
+        }
         return JfrThreadLocal.isThreadExcluded(thread);
     }
 
+    /** See {@link JVM#isExcluded(Class)}. */
     @Substitute
     public boolean isExcluded(Class<? extends jdk.internal.event.Event> eventClass) {
-        // Temporarily always include.
-        return false;
+        /* For now, assume that event classes are only excluded if JFR support is disabled. */
+        return !HasJfrSupport.get();
     }
 
+    /** See {@link JVM#isInstrumented}. */
     @Substitute
     public boolean isInstrumented(Class<? extends jdk.internal.event.Event> eventClass) {
-        // This should check for blessed commit methods in the event class [GR-41200]
-        return true;
+        /*
+         * Assume that event classes are instrumented if JFR support is present. This method should
+         * ideally check for blessed commit methods in the event class, see GR-41200.
+         */
+        return HasJfrSupport.get();
     }
 
-    /** See {@link SubstrateJVM#getChunkStartNanos}. */
+    /** See {@link JVM#getChunkStartNanos}. */
     @Substitute
     public long getChunkStartNanos() {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().getChunkStartNanos();
     }
 
+    /** See {@link JVM#setConfiguration}. */
     @Substitute
     public boolean setConfiguration(Class<? extends jdk.internal.event.Event> eventClass, Target_jdk_jfr_internal_event_EventConfiguration configuration) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().setConfiguration(eventClass, configuration);
     }
 
+    /** See {@link JVM#getConfiguration}. */
     @Substitute
     public Object getConfiguration(Class<? extends jdk.internal.event.Event> eventClass) {
+        if (!HasJfrSupport.get()) {
+            throw jfrNotSupportedException();
+        }
         return SubstrateJVM.get().getConfiguration(eventClass);
     }
 
@@ -450,26 +600,8 @@ public final class Target_jdk_jfr_internal_JVM {
     }
 }
 
-class HasChunkRotationMonitorField implements BooleanSupplier {
-    private static final boolean HAS_FIELD = ReflectionUtil.lookupField(true, JVM.class, "CHUNK_ROTATION_MONITOR") != null;
-
-    @Override
-    public boolean getAsBoolean() {
-        return HAS_FIELD;
-    }
-
-    @Fold
-    public static boolean get() {
-        return HAS_FIELD;
-    }
-}
-
-@Platforms(Platform.HOSTED_ONLY.class)
-class HasFileDeltaChangeField implements BooleanSupplier {
-    private static final boolean HAS_FIELD = ReflectionUtil.lookupField(true, JVM.class, "FILE_DELTA_CHANGE") != null;
-
-    @Override
-    public boolean getAsBoolean() {
-        return HAS_FIELD;
+class Target_jdk_jfr_internal_JVM_Util {
+    static UnsupportedOperationException jfrNotSupportedException() {
+        throw new UnsupportedOperationException(VMInspectionOptions.getJfrNotSupportedMessage());
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_event_EventConfiguration.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_event_EventConfiguration.java
@@ -26,6 +26,6 @@ package com.oracle.svm.core.jfr;
 
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "jdk.jfr.internal.event.EventConfiguration", onlyWith = HasJfrSupport.class)
+@TargetClass(className = "jdk.jfr.internal.event.EventConfiguration")
 public final class Target_jdk_jfr_internal_event_EventConfiguration {
 }


### PR DESCRIPTION
(cherry picked from commit 5a5abc7e67492f919aeede68bad450f3743a3572)

<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**
- https://github.com/oracle/graal/pull/11203

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
### `com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java`

The main changes in the cherry picked commit for this file involve guarding the calls for a check to see if JFR is enabled. Many methods became static at a [later commit](https://github.com/oracle/graal/commit/dc02e6ac6bc601450d4250ec1c38955f2074cea1), which caused several merge conflicts. I preserved the signature in the parent commit but added the guard code.

In most cases, the resolution was straightforward, but in a few cases, the body of the method changed as support was later added for JVM functionality. In these cases, I preserved the existing behavior but still added the check from the cherry-picked commit. These methods are as follows:

* `setThrottle(long eventTypeId, long eventSampleSize, long periodMs)`
* `emitOldObjectSamples(long cutoff, boolean emitAll, boolean skipBFS)`

The following methods instead take the new implementation in the cherry-picked commit; specifically, returning the value of `HasJfrSupport.get()` instead of a hardcoded value:

* `isExcluded(Class<? extends jdk.internal.event.Event> eventClass)`
* `isInstrumented(Class<? extends jdk.internal.event.Event> eventClass)`
* `isAvailable()`


### `com/oracle/svm/core/jfr/JfrJdkCompatibility.java`

This file was added later downstream but contains the core functionality for this backport. I only took the relevant changes from the downstream file and added them here.


## testing

I ran a small program compiled with `native-image` to show the differences in output with and without this patch.

### `FlightRecorder fr = FlightRecorder.getFlightRecorder();`
Before change:

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: jdk.jfr.internal.JVM.isAvailable()Z [symbol: Java_jdk_jfr_internal_JVM_isAvailable or Java_jdk_jfr_internal_JVM_isAvailable__]
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.access.JNINativeLinkage.getOrFindEntryPoint(JNINativeLinkage.java:152)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.JNIGeneratedMethodSupport.nativeCallAddress(JNIGeneratedMethodSupport.java:41)
        at jdk.jfr@23.0.2/jdk.jfr.internal.JVM.isAvailable(Native Method)
        at jdk.jfr@23.0.2/jdk.jfr.FlightRecorder.isAvailable(FlightRecorder.java:328)
        at org.example.App.main(App.java:15)
        at java.base@23.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```

After change:
```
Exception in thread "main" java.lang.IllegalStateException: Flight Recorder is not supported on this VM
        at jdk.jfr@21.0.2/jdk.jfr.internal.JVMSupport.ensureWithIllegalStateException(JVMSupport.java:77)
        at jdk.jfr@21.0.2/jdk.jfr.FlightRecorder.getFlightRecorder(FlightRecorder.java:168)
        at org.example.App.main(App.java:18)
        at java.base@21.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```


### `System.out.println("flight recorder available: " + FlightRecorder.isAvailable());`

Before change:
```
Exception in thread "main" java.lang.UnsatisfiedLinkError: jdk.jfr.internal.JVM.isAvailable()Z [symbol: Java_jdk_jfr_internal_JVM_isAvailable or Java_jdk_jfr_internal_JVM_isAvailable__]
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.access.JNINativeLinkage.getOrFindEntryPoint(JNINativeLinkage.java:152)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.JNIGeneratedMethodSupport.nativeCallAddress(JNIGeneratedMethodSupport.java:41)
        at jdk.jfr@23.0.2/jdk.jfr.internal.JVM.isAvailable(Native Method)
        at jdk.jfr@23.0.2/jdk.jfr.FlightRecorder.isAvailable(FlightRecorder.java:328)
        at org.example.App.main(App.java:15)
        at java.base@23.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```

After change:
```
flight recorder available: false
```


<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/116
