### PR TITLE
[Backport] [Oracle GraalVM] [GR-63479] Backport to 23.1: Emit additional reinterpret when generating float CAS from node matching rules.

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/replacements/test/UnsafeReplacementsTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/replacements/test/UnsafeReplacementsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,6 +153,15 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
         test("unsafeCompareAndSetLong");
         test("unsafeCompareAndSetFloat");
         test("unsafeCompareAndSetDouble");
+    }
+
+    public static Boolean unsafeCompareAndSetFloatVar(Container c) {
+        return unsafe.compareAndSetFloat(c, floatOffset, 1.0f, 2.0f);
+    }
+
+    @Test
+    public void testUnsafeCompareAndSetFloatVar() {
+        test("unsafeCompareAndSetFloatVar", new Container());
     }
 
     public static boolean unsafeWeakCompareAndSetBoolean() {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10898 (https://github.com/oracle/graal/commit/f8a4ca05236753d6c5bdca0b616c01244e5acca1)

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts [1]**

Since https://github.com/oracle/graal/commit/23cbacb7e4d11224743ae5279aaf5f06699bf11a on mainline emitCompareAndSwapBranch & emitCompareAndSwapOp have isLogic parameter:
```diff
-    public void emitCompareAndSwapBranch(LIRKind kind, AMD64AddressValue address, Value expectedValue, Value newValue, Condition condition, LabelRef trueLabel, LabelRef falseLabel,
+    public void emitCompareAndSwapBranch(boolean isLogic, LIRKind kind, AMD64AddressValue address, Value expectedValue, Value newValue, Condition condition, LabelRef trueLabel, LabelRef falseLabel,

-    public void emitCompareAndSwapOp(LIRGeneratorTool tool, LIRKind accessKind, AMD64Kind memKind, RegisterValue raxValue, AMD64AddressValue address, AllocatableValue newValue,
+    public void emitCompareAndSwapOp(LIRGeneratorTool tool, boolean isLogic, LIRKind accessKind, AMD64Kind memKind, RegisterValue raxValue, AMD64AddressValue address, AllocatableValue newValue,
```

This is the merge conflict:
```
<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
        emitCompareAndSwapOp(integerAccessKind, memKind, aRes, addressValue, allocatableNewValue, barrierType);
=======
        emitCompareAndSwapOp(isLogic, integerAccessKind, memKind, aRes, addressValue, allocatableNewValue, barrierType);
        return aRes;
    }

    private Value emitCompareAndSwap(boolean isLogic, LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, BarrierType barrierType) {
        Value aRes = emitCompareAndSwapHelper(isLogic, accessKind, address, expectedValue, newValue, barrierType);
>>>>>>> f8a4ca05236 (Emit additional reinterpret when generating float CAS from node matching rules):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/core/amd64/AMD64LIRGenerator.java

<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
        assert kind.getPlatformKind().getSizeInBytes() <= expectedValue.getValueKind().getPlatformKind().getSizeInBytes();
        assert kind.getPlatformKind().getSizeInBytes() <= newValue.getValueKind().getPlatformKind().getSizeInBytes();
        assert condition == Condition.EQ || condition == Condition.NE;
        AMD64Kind memKind = (AMD64Kind) kind.getPlatformKind();
        RegisterValue raxValue = AMD64.rax.asValue(kind);
        emitMove(raxValue, expectedValue);
        emitCompareAndSwapOp(kind, memKind, raxValue, address, asAllocatable(newValue), barrierType);
=======
        GraalError.guarantee(kind.getPlatformKind().getSizeInBytes() <= expectedValue.getValueKind().getPlatformKind().getSizeInBytes(), "kind=%s, expectedValue=%s", kind, expectedValue);
        GraalError.guarantee(kind.getPlatformKind().getSizeInBytes() <= newValue.getValueKind().getPlatformKind().getSizeInBytes(), "kind=%s, newValue=%s", kind, newValue);
        GraalError.guarantee(condition == Condition.EQ || condition == Condition.NE, Assertions.errorMessage(condition, address, expectedValue, newValue));

        emitCompareAndSwapHelper(isLogic, kind, address, expectedValue, newValue, barrierType);
>>>>>>> f8a4ca05236 (Emit additional reinterpret when generating float CAS from node matching rules):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/core/amd64/AMD64LIRGenerator.java
```
Resolution: skip the parameter.

**Conflicts [2]** Build issue:

On mainline Assertions.errorMessage is defined in https://github.com/oracle/graal/commit/ec49d5031bf05b3cd265c9f1de6c8ffdb05b598d change. Replaced Assertions.errorMessage(...) with an inline formatted message passed directly to GraalError.guarantee(...).

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/115
