### PR TITLE
[Backport] [Oracle GraalVM] [GR-62678] Backport to 23.1 : System.out/err usage in PolyglotLoggers.

### DIFF
--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -63,6 +63,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import com.oracle.svm.core.log.Log;
 import org.graalvm.collections.Pair;
 import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
 import org.graalvm.compiler.nodes.ConstantNode;
@@ -1477,6 +1478,17 @@ final class Target_com_oracle_truffle_polyglot_InternalResourceCache {
         @Override
         public Object transform(Object receiver, Object originalValue) {
             return TruffleBaseFeature.Options.CopyLanguageResources.getValue();
+        }
+    }
+}
+
+@TargetClass(className = "com.oracle.truffle.polyglot.PolyglotEngineImpl", onlyWith = TruffleBaseFeature.IsEnabled.class)
+final class Target_com_oracle_truffle_polyglot_PolyglotEngineImpl {
+    @Substitute
+    static void logFallback(String message) {
+        try (Log log = Log.log()) {
+            log.string(message.getBytes(StandardCharsets.UTF_8));
+            log.flush();
         }
     }
 }

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/InstrumentCache.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/InstrumentCache.java
@@ -40,7 +40,6 @@
  */
 package com.oracle.truffle.polyglot;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -298,8 +297,7 @@ final class InstrumentCache {
     }
 
     private static void emitWarning(String message, Object... args) {
-        PrintStream out = System.err;
-        out.printf(message + "%n", args);
+        PolyglotEngineImpl.logFallback(String.format(message + "%n", args));
     }
 
     private interface ProviderAdapter {

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/InternalResourceRoots.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/InternalResourceRoots.java
@@ -47,7 +47,6 @@ import org.graalvm.collections.Pair;
 import org.graalvm.nativeimage.ImageInfo;
 import org.graalvm.nativeimage.ProcessProperties;
 
-import java.io.PrintStream;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -307,8 +306,7 @@ final class InternalResourceRoots {
     }
 
     private static void emitWarning(String message, Object... args) {
-        PrintStream out = System.err;
-        out.printf(message + "%n", args);
+        PolyglotEngineImpl.logFallback(String.format(message + "%n", args));
     }
 
     record Root(Path path, Kind kind, List<InternalResourceCache> caches) {

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/LanguageCache.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/LanguageCache.java
@@ -41,7 +41,6 @@
 package com.oracle.truffle.polyglot;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.net.JarURLConnection;
 import java.net.URISyntaxException;
@@ -689,8 +688,7 @@ final class LanguageCache implements Comparable<LanguageCache> {
     }
 
     private static void emitWarning(String message, Object... args) {
-        PrintStream out = System.err;
-        out.printf(message + "%n", args);
+        PolyglotEngineImpl.logFallback(String.format(message + "%n", args));
     }
 
     private static final class HostLanguageProvider extends TruffleLanguageProvider {

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineImpl.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineImpl.java
@@ -2339,4 +2339,19 @@ final class PolyglotEngineImpl implements com.oracle.truffle.polyglot.PolyglotIm
         return languageHomes;
     }
 
+    /**
+     * Logs a message when other logging mechanisms, such as {@link TruffleLogger} or the context's
+     * error stream, are unavailable. This can occur, for instance, in the event of a log handler
+     * failure.
+     * <p>
+     * On HotSpot, this method writes the message to {@code System.err}. When running on a native
+     * image, this method is substituted to delegate logging to the native image's
+     * {@link org.graalvm.nativeimage.LogHandler}.
+     *
+     * @param message the message to log
+     */
+    static void logFallback(String message) {
+        PrintStream err = System.err;
+        err.println(message);
+    }
 }

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotLoggers.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotLoggers.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.logging.ErrorManager;
 import java.util.logging.Formatter;
@@ -293,7 +294,7 @@ final class PolyglotLoggers {
 
         final synchronized void reportHandlerError(int errorKind, Throwable t) {
             if (errorManager == null) {
-                errorManager = new ErrorManager();
+                errorManager = new PolyglotErrorManager();
             }
             Exception exception;
             if (t instanceof Exception) {
@@ -775,6 +776,33 @@ final class PolyglotLoggers {
                 }
             }
             return EngineAccessor.LANGUAGE.getLogger(loggerId, null, loggersCache);
+        }
+    }
+
+    private static final class PolyglotErrorManager extends ErrorManager {
+
+        private final AtomicBoolean reported = new AtomicBoolean();
+
+        PolyglotErrorManager() {
+        }
+
+        @Override
+        public void error(String msg, Exception ex, int code) {
+            if (reported.getAndSet(true)) {
+                return;
+            }
+            StringWriter content = new StringWriter();
+            try (PrintWriter out = new PrintWriter(content)) {
+                String text = "java.util.logging.ErrorManager: " + code;
+                if (msg != null) {
+                    text = text + ": " + msg;
+                }
+                out.println(text);
+                if (ex != null) {
+                    ex.printStackTrace(out);
+                }
+            }
+            PolyglotEngineImpl.logFallback(content.toString());
         }
     }
 }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10231

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 
- skipped: change in JDKSupport.java as the file was deleted in graalvm-community-jdk21u. 
- skipped: change in PolyglotEngineImpl.logCloseOnCollectedError (introduced in mainline only, https://github.com/oracle/graal/commit/c6b9e49f953347bf61b4d1ea2ecc3a9ae29c39ca)

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/105
