### PR TITLE
[Backport] [GR-59858] Mark type of hidden field reachable.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -544,6 +544,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
                 AnalysisField subclassField = (AnalysisField) javaField;
                 if (subclassField.getName().equals(field.getName())) {
                     hidingFields.add(subclassField);
+                    subclassField.getType().registerAsReachable("Is the declared type of a hiding Field used by reflection");
                 }
             }
         } catch (UnsupportedFeatureException | LinkageError e) {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10104
   - https://github.com/oracle/graal/commit/d6da064e

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
- Skipped change in markTypeInstantiated: not applicable — AnalysisType::registerAsInstantiated is not implemented.
- Skipped objectType.registerAsReachable call: the corresponding code does not exist in this codebase.
- Skipped change in NativeImageCodeCache.java: it modifies code introduced later, and relates only to a guarantee report, which is not important.

<details>

```
git cherry-pick f642457aa0d1fc67ab85eb7b4c62cf4946084164 -x
CONFLICT (content): Merge conflict in substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeapScanner.java
CONFLICT (content): Merge conflict in substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageCodeCache.java
CONFLICT (content): Merge conflict in substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
```

```
$ awk '/^<<<<<<< /{flag=1} flag; /^>>>>>>> /{flag=0}' substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageCodeCache.java
<<<<<<< HEAD
        CodeInfoEncoder.Encoders encoders = new CodeInfoEncoder.Encoders();
        CodeInfoEncoder codeInfoEncoder = new CodeInfoEncoder(frameInfoCustomization, encoders);
=======
        CodeInfoEncoder.Encoders encoders = new CodeInfoEncoder.Encoders(true, clazz -> {
            if (clazz != null) {
                Optional<HostedType> hostedType = imageHeap.hMetaAccess.optionalLookupJavaType(clazz);
                if (hostedType.isPresent()) {
                    boolean reachable = hostedType.get().getWrapped().isReachable();
                    VMError.guarantee(reachable, "Type added to the runtime metadata was seen by the analysis, but not marked as reachable: %s", clazz);
                } else {
                    throw VMError.shouldNotReachHere("Type added to the runtime metadata without being seen by the analysis: %s", clazz);
                }
            }
        });
        HostedConstantAccess hostedConstantAccess = new HostedConstantAccess(snippetReflection);
        CodeInfoEncoder codeInfoEncoder = new CodeInfoEncoder(frameInfoCustomization, encoders, hostedConstantAccess);
        DeadlockWatchdog watchdog = ImageSingletons.lookup(DeadlockWatchdog.class);
>>>>>>> f642457aa0d (Mark type of hidden field reachable.)
```

```
$ awk '/^<<<<<<< /{flag=1} flag; /^>>>>>>> /{flag=0}' substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
<<<<<<< HEAD
                AnalysisField subclassField = (AnalysisField) javaField;
                if (subclassField.getName().equals(field.getName())) {
                    hidingFields.add(subclassField);
=======
                for (AnalysisField registeredField : superclassFields) {
                    AnalysisField subclassField = (AnalysisField) javaField;
                    if (subclassField.getName().equals(registeredField.getName())) {
                        hidingFields.add(subclassField);
                        subclassField.getType().registerAsReachable("Is the declared type of a hiding Field used by reflection");
                    }
>>>>>>> f642457aa0d (Mark type of hidden field reachable.)
```

```
$ awk '/^<<<<<<< /{flag=1} flag; /^>>>>>>> /{flag=0}' substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeapScanner.java
<<<<<<< HEAD
    void markTypeInstantiated(AnalysisType type, ScanReason reason) {
        if (universe.sealed() && !type.isReachable()) {
            throw AnalysisError.shouldNotReachHere("Universe is sealed. New type reachable: " + type.toJavaName());
        }
        universe.getBigbang().registerTypeAsInHeap(type, reason);
=======
    void markTypeReachable(AnalysisType type, ScanReason reason) {
        if (universe.sealed() && !type.isReachable()) {
            throw AnalysisError.typeNotFound(type);
        }
        type.registerAsReachable(reason);
    }

    void markTypeInstantiated(AnalysisType type, ScanReason reason) {
        if (universe.sealed() && !type.isInstantiated()) {
            throw AnalysisError.typeNotFound(type);
        }
        type.registerAsInstantiated(reason);
>>>>>>> f642457aa0d (Mark type of hidden field reachable.)

<<<<<<< HEAD
=======
    private void ensureFieldPositionsComputed(ImageHeapConstant baseLayerConstant, ScanReason reason) {
        AnalysisType objectType = baseLayerConstant.getType();
        markTypeReachable(objectType, reason);
        objectType.getStaticFields();
        objectType.getInstanceFields(true);
    }

    private void checkSealed(ScanReason reason, String format, Object... args) {
        if (sealed && reason != OtherReason.LATE_SCAN) {
            throw AnalysisError.sealedHeapError(HeapSnapshotVerifier.formatReason(bb, reason, format, args));
        }
    }

>>>>>>> f642457aa0d (Mark type of hidden field reachable.)

<<<<<<< HEAD
        ScanReason arrayReason = new ArrayScan(type, constant, reason);
        for (int idx = 0; idx < length; idx++) {
            final JavaConstant rawElementValue = constantReflection.readArrayElement(constant, idx);
            int finalIdx = idx;
            array.setElementTask(idx, new AnalysisFuture<>(() -> {
                JavaConstant arrayElement = createImageHeapConstant(rawElementValue, arrayReason);
                array.setElement(finalIdx, arrayElement);
                return arrayElement;
            }));
        }
=======
        /* Read hosted array element values only when the array is initialized. */
        array.constantData.hostedValuesReader = new AnalysisFuture<>(() -> {
            checkSealed(reason, "Trying to materialize an ImageHeapObjectArray for %s after the ImageHeapScanner is sealed.", constant);
            markTypeReachable(type, reason);
            ScanReason arrayReason = new ArrayScan(type, array, reason);
            Object[] elementValues = new Object[length];
            for (int idx = 0; idx < length; idx++) {
                final JavaConstant rawElementValue = hostedValuesProvider.readArrayElement(constant, idx);
                int finalIdx = idx;
                elementValues[idx] = new AnalysisFuture<>(() -> {
                    JavaConstant arrayElement = createImageHeapConstant(rawElementValue, arrayReason);
                    array.setElement(finalIdx, arrayElement);
                    return arrayElement;
                });
            }
            array.setElementValues(elementValues);
        });
>>>>>>> f642457aa0d (Mark type of hidden field reachable.)

<<<<<<< HEAD
        /* We are about to query the type's fields, the type must be marked as reachable. */
        type.registerAsReachable(reason);
        ResolvedJavaField[] instanceFields = type.getInstanceFields(true);
        ImageHeapInstance instance = new ImageHeapInstance(type, constant, instanceFields.length);
        for (ResolvedJavaField javaField : instanceFields) {
            AnalysisField field = (AnalysisField) javaField;
            ValueSupplier<JavaConstant> rawFieldValue;
            try {
                rawFieldValue = readHostedFieldValue(field, universe.toHosted(constant));
            } catch (InternalError | TypeNotPresentException | LinkageError e) {
                /* Ignore missing type errors. */
                continue;
            }
            instance.setFieldTask(field, new AnalysisFuture<>(() -> {
                ScanReason fieldReason = new FieldScan(field, constant, reason);
                JavaConstant value = createFieldValue(field, instance, rawFieldValue, fieldReason);
                instance.setFieldValue(field, value);
                return value;
            }));
        }
=======
        ImageHeapInstance instance = new ImageHeapInstance(type, constant);
        /* Read hosted field values only when the receiver is initialized. */
        instance.constantData.hostedValuesReader = new AnalysisFuture<>(() -> {
            checkSealed(reason, "Trying to materialize an ImageHeapInstance for %s after the ImageHeapScanner is sealed.", constant);
            /* If this is a Class constant register the corresponding type as reachable. */
            AnalysisType typeFromClassConstant = (AnalysisType) constantReflection.asJavaType(instance);
            if (typeFromClassConstant != null) {
                markTypeReachable(typeFromClassConstant, reason);
            }
            /* We are about to query the type's fields, the type must be marked as reachable. */
            markTypeReachable(type, reason);
            ResolvedJavaField[] instanceFields = type.getInstanceFields(true);
            Object[] hostedFieldValues = new Object[instanceFields.length];
            for (ResolvedJavaField javaField : instanceFields) {
                AnalysisField field = (AnalysisField) javaField;
                ValueSupplier<JavaConstant> rawFieldValue;
                if (!type.isInitialized()) {
                    /*
                     * We cannot read the hosted value of an object whose type is initialized at run
                     * time. If the object is marked as reachable later on, it will be reported as
                     * an unsupported feature. But we must not fail here earlier with an internal
                     * error.
                     */
                    rawFieldValue = ValueSupplier.lazyValue(() -> null, () -> false);
                } else {
                    try {
                        rawFieldValue = readHostedFieldValue(field, constant);
                    } catch (InternalError | TypeNotPresentException | LinkageError e) {
                        /* Ignore missing type errors. */
                        continue;
                    }
                }
                hostedFieldValues[field.getPosition()] = new AnalysisFuture<>(() -> {
                    ScanReason fieldReason = new FieldScan(field, instance, reason);
                    JavaConstant value = createFieldValue(field, instance, rawFieldValue, fieldReason);
                    instance.setFieldValue(field, value);
                    return value;
                });
            }
            instance.setFieldValues(hostedFieldValues);
        });
>>>>>>> f642457aa0d (Mark type of hidden field reachable.)
```
</details>

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/88
