### PR TITLE
[GR-59408] Infinite recursion in AArch64MacroAssembler.add/sub with immediate = Integer.MIN_VALUE

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/aarch64/test/AddSubInfiniteRecursionTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/aarch64/test/AddSubInfiniteRecursionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.core.test.GraalCompilerTest;
+import org.junit.Test;
+
+/**
+ * Add/sub with an immediate MIN_VALUE may result in infinite recursion since MIN_VALUE < 0 and
+ * -MIN_VALUE < 0.
+ */
+public class AddSubInfiniteRecursionTest extends GraalCompilerTest {
+    public static int testAddIntMinValue(int arg) {
+        return arg + Integer.MIN_VALUE;
+    }
+
+    public static int testSubIntMinValue(int arg) {
+        return arg - Integer.MIN_VALUE;
+    }
+
+    @Test
+    public void runIntMinValue() {
+        test("testAddIntMinValue", 0);
+        test("testSubIntMinValue", 0);
+    }
+}

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -1084,7 +1084,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      */
     public void add(int size, Register dst, Register src, int immediate, Register scratch) {
         assert (!dst.equals(zr) && !src.equals(zr));
-        if (immediate < 0) {
+        if (-immediate > 0) {
             sub(size, dst, src, -immediate, scratch);
         } else if (NumUtil.isUnsignedNbit(24, immediate) || !dst.equals(src)) {
             add(size, dst, src, immediate);
@@ -1109,7 +1109,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     @Override
     public void add(int size, Register dst, Register src, int immediate) {
         assert (!dst.equals(zr) && !src.equals(zr));
-        if (immediate < 0) {
+        if (-immediate > 0) {
             sub(size, dst, src, -immediate);
         } else if (isAddSubtractImmediate(immediate, false)) {
             if (!(dst.equals(src) && immediate == 0)) {
@@ -1156,7 +1156,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     @Override
     public void adds(int size, Register dst, Register src, int immediate) {
         assert (!dst.equals(sp) && !src.equals(zr));
-        if (immediate < 0) {
+        if (-immediate > 0) {
             subs(size, dst, src, -immediate);
         } else {
             super.adds(size, dst, src, immediate);
@@ -1176,7 +1176,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      */
     public void sub(int size, Register dst, Register src, int immediate, Register scratch) {
         assert (!dst.equals(zr) && !src.equals(zr));
-        if (immediate < 0) {
+        if (-immediate > 0) {
             add(size, dst, src, -immediate, scratch);
         }
         if (NumUtil.isUnsignedNbit(24, immediate) || !dst.equals(src)) {
@@ -1202,7 +1202,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     @Override
     public void sub(int size, Register dst, Register src, int immediate) {
         assert (!dst.equals(zr) && !src.equals(zr));
-        if (immediate < 0) {
+        if (-immediate > 0) {
             add(size, dst, src, -immediate);
         } else if (isAddSubtractImmediate(immediate, false)) {
             if (!(dst.equals(src) && immediate == 0)) {
@@ -1229,7 +1229,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     @Override
     public void subs(int size, Register dst, Register src, int immediate) {
         assert (!dst.equals(sp) && !src.equals(zr));
-        if (immediate < 0) {
+        if (-immediate > 0) {
             adds(size, dst, src, -immediate);
         } else {
             super.subs(size, dst, src, immediate);


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/9979

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 

Minor conflicts due to changes in asserts nearby:
```
<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
        assert (!dst.equals(sp) && !src.equals(zr));
        if (immediate < 0) {
=======
        assert (!dst.equals(sp) && !src.equals(zr)) : dst + " " + src;
        if (-immediate > 0) {
>>>>>>> d48052359e9 (Infinite recursion in AArch64MacroAssembler.add/sub with immediate = Integer.MIN_VALUE):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/asm/aarch64/AArch64MacroAssembler.java
```

The test was moved to the proper package:
- from package jdk.graal.compiler.core.aarch64.test
- to package org.graalvm.compiler.core.aarch64.test
- from compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/core/aarch64/test/
- to compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/core/aarch64/test/

<!-- Add the backport issue that this PR closes -->
It is a part of: [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)
