### PR TITLE
[Backport][GR-45020] Do not permit FixedGuardNode and ConditionAnchorNode to go away if there are PiNodes attached

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/FixedGuardNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/FixedGuardNode.java
@@ -36,6 +36,7 @@ import org.graalvm.compiler.graph.NodeSourcePosition;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ProfileData.ProfileSource;
 import org.graalvm.compiler.nodes.calc.IntegerEqualsNode;
+import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
 import org.graalvm.compiler.nodes.spi.Lowerable;
 import org.graalvm.compiler.nodes.spi.LoweringTool;
 import org.graalvm.compiler.nodes.spi.SimplifierTool;
@@ -88,8 +89,27 @@ public final class FixedGuardNode extends AbstractFixedGuardNode implements Lowe
                 GraphUtil.killCFG(this);
                 return;
             }
-            this.replaceAtUsages(null);
-            graph().removeFixed(this);
+            if (hasUsages()) {
+                /*
+                 * Try to eliminate any exposed usages. We could always just insert the
+                 * ValueAnchorNode and let canonicalization clean it up but since it almost always
+                 * trivially removable it's better to clean it up here. This also means that any
+                 * actual insertions of a ValueAnchorNode by this code indicates a real mismatch
+                 * between the piStamp and it's input.
+                 */
+                PiNode.evacuate(tool, this);
+            }
+            if (hasUsages()) {
+                /*
+                 * There are still guard usages after simplification so preserve this anchor point.
+                 * It may still go away after further simplification but any uses that hang around
+                 * are required to be anchored. After guard lowering it might be possible to replace
+                 * the ValueAnchorNode with the Begin of the current block.
+                 */
+                graph().replaceFixedWithFixed(this, graph().add(new ValueAnchorNode()));
+            } else {
+                graph().removeFixed(this);
+            }
         } else if (getCondition() instanceof ShortCircuitOrNode) {
             ShortCircuitOrNode shortCircuitOr = (ShortCircuitOrNode) getCondition();
             if (isNegated() && hasNoUsages()) {

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/FixedGuardNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/FixedGuardNode.java
@@ -92,12 +92,12 @@ public final class FixedGuardNode extends AbstractFixedGuardNode implements Lowe
             if (hasUsages()) {
                 /*
                  * Try to eliminate any exposed usages. We could always just insert the
-                 * ValueAnchorNode and let canonicalization clean it up but since it almost always
+                 * ValueAnchorNode and let canonicalization clean it up but since it's almost always
                  * trivially removable it's better to clean it up here. This also means that any
                  * actual insertions of a ValueAnchorNode by this code indicates a real mismatch
-                 * between the piStamp and it's input.
+                 * between the piStamp and its input.
                  */
-                PiNode.evacuate(tool, this);
+                PiNode.tryEvacuate(tool, this);
             }
             if (hasUsages()) {
                 /*

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/PiNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/PiNode.java
@@ -295,13 +295,14 @@ public class PiNode extends FloatingGuardedNode implements LIRLowerable, Virtual
 
     /**
      * Perform Pi canonicalizations on any PiNodes anchored at {@code user} in an attempt to
-     * eliminate all of them.
+     * eliminate all of them. This purely done to enable earlier elimination of the user of these
+     * PiNodes.
      */
-    public static void evacuate(SimplifierTool tool, Node user) {
-        evacuate(tool, user, true);
+    public static void tryEvacuate(SimplifierTool tool, Node user) {
+        tryEvacuate(tool, user, true);
     }
 
-    private static void evacuate(SimplifierTool tool, Node user, boolean recurse) {
+    private static void tryEvacuate(SimplifierTool tool, Node user, boolean recurse) {
         if (!user.hasUsages()) {
             return;
         }
@@ -325,7 +326,7 @@ public class PiNode extends FloatingGuardedNode implements LIRLowerable, Virtual
                 // this PiNode so try to simplify the input first.
                 GuardingNode guard = ((PiNode) pi.getOriginalNode()).guard;
                 if (guard != null) {
-                    evacuate(tool, guard.asNode(), false);
+                    tryEvacuate(tool, guard.asNode(), false);
                 }
             }
             Node canonical = pi.canonical(tool);

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/PiNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/PiNode.java
@@ -304,7 +304,7 @@ public class PiNode extends FloatingGuardedNode implements LIRLowerable, Virtual
 
     private static void tryEvacuate(SimplifierTool tool, GuardingNode guard, boolean recurse) {
         ValueNode guardNode = guard.asNode();
-        if (!guardNode.hasUsages()) {
+        if (guardNode.hasNoUsages()) {
             return;
         }
         for (PiNode pi : guardNode.usages().filter(PiNode.class).snapshot()) {

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/substitutions/TruffleGraphBuilderPlugins.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/substitutions/TruffleGraphBuilderPlugins.java
@@ -1150,10 +1150,14 @@ public class TruffleGraphBuilderPlugins {
                     locationIdentity = ObjectLocationIdentity.create(location.asJavaConstant());
                     forceLocation = true;
                 }
-                LogicNode compare = b.add(CompareNode.createCompareNode(b.getConstantReflection(), b.getMetaAccess(), b.getOptions(), null, CanonicalCondition.EQ, condition,
-                                ConstantNode.forBoolean(true, object.graph()), NodeView.DEFAULT));
-                ConditionAnchorNode anchor = b.add(new ConditionAnchorNode(compare));
-                b.addPush(returnKind, b.add(new GuardedUnsafeLoadNode(b.addNonNullCast(object), offset, returnKind, locationIdentity, anchor, forceLocation)));
+                ValueNode guard = null;
+                // If the condition is the constant true then no guard is needed
+                if (!condition.isConstant() || condition.asJavaConstant().asInt() == 0) {
+                    LogicNode compare = b.add(CompareNode.createCompareNode(b.getConstantReflection(), b.getMetaAccess(), b.getOptions(), null, CanonicalCondition.EQ, condition,
+                                    ConstantNode.forBoolean(true, object.graph()), NodeView.DEFAULT));
+                    guard = b.add(new ConditionAnchorNode(compare));
+                }
+                b.addPush(returnKind, b.add(new GuardedUnsafeLoadNode(b.addNonNullCast(object), offset, returnKind, locationIdentity, guard, forceLocation)));
                 return true;
             } else if (canDelayIntrinsification) {
                 return false;


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/7385

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 
Minor conflict around [Simplify ValueAnchorNode implementation](https://github.com/oracle/graal/commit/d2ddd2b83f5dcbb59e6862fb9a6a452e4c451a1e) change: ValueAnchorNode(null)->ValueAnchorNode()
<details>

```
<<<<<<< HEAD
            if (c.getValue() != negated) {
                return null;
            } else {
                return new ValueAnchorNode();
=======
            // An anchor that still has usages must still exist since it's possible the condition is
            // true for control flow reasons so the Pi stamp is also only valid for those reason.
            if (c.getValue() == negated || hasUsages()) {
                return new ValueAnchorNode(null);
            } else {
                return null;
>>>>>>> 161b078bc21 (Do not permit FixedGuardNode and ConditionAnchorNode to go away if there are PiNodes attached)
```
</details>

Closes: (none)
It is a part of: [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)