### PR TITLE
[Backport][GR-52557] Pi node: guard against deletion in recursion.

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/PiNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/PiNode.java
@@ -27,6 +27,8 @@ package org.graalvm.compiler.nodes;
 import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_0;
 import static org.graalvm.compiler.nodeinfo.NodeSize.SIZE_0;
 
+import java.util.List;
+
 import org.graalvm.compiler.core.common.type.AbstractPointerStamp;
 import org.graalvm.compiler.core.common.type.ObjectStamp;
 import org.graalvm.compiler.core.common.type.Stamp;
@@ -307,7 +309,9 @@ public class PiNode extends FloatingGuardedNode implements LIRLowerable, Virtual
         if (guardNode.hasNoUsages()) {
             return;
         }
-        for (PiNode pi : guardNode.usages().filter(PiNode.class).snapshot()) {
+
+        List<PiNode> pis = guardNode.usages().filter(PiNode.class).snapshot();
+        for (PiNode pi : pis) {
             if (!pi.isAlive()) {
                 continue;
             }
@@ -317,6 +321,8 @@ public class PiNode extends FloatingGuardedNode implements LIRLowerable, Virtual
             }
 
             /*
+             * RECURSE CALL
+             *
              * If there are PiNodes still anchored at this guard then either they must simplify away
              * because they are no longer necessary or this node must be replaced with a
              * ValueAnchorNode because the type injected by the PiNode is only true at this point in
@@ -329,6 +335,16 @@ public class PiNode extends FloatingGuardedNode implements LIRLowerable, Virtual
                 if (otherGuard != null) {
                     tryEvacuate(tool, otherGuard, false);
                 }
+            }
+            /*
+             * A note on the RECURSE CALL above: When we have pis with input pis on the same guard
+             * (which should actually be combined) it can be that the recurse call (processing the
+             * same pis again) already deletes this node (very special stamp setups necessary).
+             * Thus, it can be that pi is dead at this point already, so we have to check for this
+             * again.
+             */
+            if (!pi.isAlive()) {
+                continue;
             }
             Node canonical = pi.canonical(tool);
             if (canonical != pi) {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/8573

**Conflicts:**
A minor conflict regarding comment removal: `// GR-52557`
Applies cleanly only after https://github.com/graalvm/graalvm-community-jdk21u/pull/150

Closes: (none)
It is a part of: [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)
