### PR TITLE
[Backport][GR-59582] Better messages for OutOfMemoryErrors and small cleanups/bugfixes.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
@@ -37,6 +37,7 @@ import com.oracle.svm.core.heap.GCCause;
 import com.oracle.svm.core.heap.PhysicalMemory;
 import com.oracle.svm.core.heap.ReferenceAccess;
 import com.oracle.svm.core.util.TimeUtils;
+import com.oracle.svm.core.util.UnsignedUtils;
 import com.oracle.svm.core.util.VMError;
 
 /** Basic/legacy garbage collection policies. */
@@ -109,9 +110,7 @@ final class BasicCollectionPolicies {
                 int maximumHeapSizePercent = HeapParameters.getMaximumHeapSizePercent();
                 /* Do not cache because `-Xmx` option parsing may not have happened yet. */
                 UnsignedWord result = physicalMemorySize.unsignedDivide(100).multiply(maximumHeapSizePercent);
-                if (result.belowThan(addressSpaceSize)) {
-                    return result;
-                }
+                return UnsignedUtils.min(result, addressSpaceSize);
             }
             return addressSpaceSize;
         }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunkProvider.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunkProvider.java
@@ -55,6 +55,10 @@ import com.oracle.svm.core.util.UnsignedUtils;
  * list. Memory for unaligned chunks is released immediately.
  */
 final class HeapChunkProvider {
+    /** These {@link OutOfMemoryError}s are only needed for legacy code, see GR-59639. */
+    private static final OutOfMemoryError ALIGNED_OUT_OF_MEMORY_ERROR = new OutOfMemoryError("Could not allocate an aligned heap chunk");
+    private static final OutOfMemoryError UNALIGNED_OUT_OF_MEMORY_ERROR = new OutOfMemoryError("Could not allocate an unaligned heap chunk");
+
     /**
      * The head of the linked list of unused aligned chunks. Chunks are chained using
      * {@link HeapChunk#getNext}.
@@ -78,10 +82,6 @@ final class HeapChunkProvider {
     public UnsignedWord getBytesInUnusedChunks() {
         return numUnusedAlignedChunks.get().multiply(HeapParameters.getAlignedHeapChunkSize());
     }
-
-    private static final OutOfMemoryError ALIGNED_OUT_OF_MEMORY_ERROR = new OutOfMemoryError("Could not allocate an aligned heap chunk");
-
-    private static final OutOfMemoryError UNALIGNED_OUT_OF_MEMORY_ERROR = new OutOfMemoryError("Could not allocate an unaligned heap chunk");
 
     /** Acquire a new AlignedHeapChunk, either from the free list or from the operating system. */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapParameters.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapParameters.java
@@ -109,13 +109,13 @@ public final class HeapParameters {
 
     static int getMaximumYoungGenerationSizePercent() {
         int result = SerialAndEpsilonGCOptions.MaximumYoungGenerationSizePercent.getValue();
-        VMError.guarantee((result >= 0) && (result <= 100), "MaximumYoungGenerationSizePercent should be in [0 ..100]");
+        VMError.guarantee(result >= 0 && result <= 100, "MaximumYoungGenerationSizePercent should be in [0..100]");
         return result;
     }
 
     static int getMaximumHeapSizePercent() {
         int result = SerialAndEpsilonGCOptions.MaximumHeapSizePercent.getValue();
-        VMError.guarantee((result >= 0) && (result <= 100), "MaximumHeapSizePercent should be in [0 ..100]");
+        VMError.guarantee(result >= 0 && result <= 100, "MaximumHeapSizePercent should be in [0..100]");
         return result;
     }
 

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsPhysicalMemorySupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsPhysicalMemorySupportImpl.java
@@ -24,10 +24,13 @@
  */
 package com.oracle.svm.core.windows;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.nativeimage.c.struct.SizeOf;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordFactory;
 
+import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredImageSingleton;
 import com.oracle.svm.core.graal.stackvalue.UnsafeStackValue;
 import com.oracle.svm.core.heap.PhysicalMemory.PhysicalMemorySupport;
@@ -37,6 +40,7 @@ import com.oracle.svm.core.windows.headers.SysinfoAPI;
 class WindowsPhysicalMemorySupportImpl implements PhysicalMemorySupport {
 
     @Override
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public UnsignedWord size() {
         SysinfoAPI.MEMORYSTATUSEX memStatusEx = UnsafeStackValue.get(SysinfoAPI.MEMORYSTATUSEX.class);
         memStatusEx.set_dwLength(SizeOf.get(SysinfoAPI.MEMORYSTATUSEX.class));

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
@@ -429,8 +429,9 @@ public class IsolateArgumentParser {
 
     @Fold
     public static int getOptionIndex(RuntimeOptionKey<?> key) {
-        for (int i = 0; i < OPTIONS.length; i++) {
-            if (OPTIONS[i] == key) {
+        RuntimeOptionKey<?>[] options = OPTIONS;
+        for (int i = 0; i < options.length; i++) {
+            if (options[i] == key) {
                 return i;
             }
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
@@ -47,7 +47,7 @@ public class SubstrateGCOptions {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Long oldValue, Long newValue) {
             if (!SubstrateUtil.HOSTED) {
-                HeapSizeVerifier.verifyMinHeapSizeAgainstAddressSpace(WordFactory.unsigned(newValue));
+                HeapSizeVerifier.verifyMinHeapSizeAgainstMaxAddressSpaceSize(WordFactory.unsigned(newValue));
             }
             super.onValueUpdate(values, oldValue, newValue);
         }
@@ -58,7 +58,7 @@ public class SubstrateGCOptions {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Long oldValue, Long newValue) {
             if (!SubstrateUtil.HOSTED) {
-                HeapSizeVerifier.verifyMaxHeapSizeAgainstAddressSpace(WordFactory.unsigned(newValue));
+                HeapSizeVerifier.verifyMaxHeapSizeAgainstMaxAddressSpaceSize(WordFactory.unsigned(newValue));
             }
             super.onValueUpdate(values, oldValue, newValue);
         }
@@ -69,7 +69,7 @@ public class SubstrateGCOptions {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Long oldValue, Long newValue) {
             if (!SubstrateUtil.HOSTED) {
-                HeapSizeVerifier.verifyMaxNewSizeAgainstAddressSpace(WordFactory.unsigned(newValue));
+                HeapSizeVerifier.verifyMaxNewSizeAgainstMaxAddressSpaceSize(WordFactory.unsigned(newValue));
             }
             super.onValueUpdate(values, oldValue, newValue);
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/AbstractRuntimeCodeInstaller.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/AbstractRuntimeCodeInstaller.java
@@ -41,7 +41,7 @@ public class AbstractRuntimeCodeInstaller {
     protected Pointer allocateCodeMemory(long size) {
         PointerBase result = RuntimeCodeInfoAccess.allocateCodeMemory(WordFactory.unsigned(size));
         if (result.isNull()) {
-            throw new OutOfMemoryError();
+            throw new OutOfMemoryError("Could not allocate memory for runtime-compiled code.");
         }
         return (Pointer) result;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -314,9 +314,8 @@ public class JfrTypeRepository implements JfrRepository {
                 return flushedClassLoaders.get(classLoader);
             }
             return typeInfo.classLoaders.get(classLoader);
-        } else {
-            return 0;
         }
+        return 0;
     }
 
     private void clearEpochData() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractImageHeapProvider.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractImageHeapProvider.java
@@ -41,7 +41,7 @@ public abstract class AbstractImageHeapProvider implements ImageHeapProvider {
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    protected static UnsignedWord getImageHeapSizeInFile() {
+    public static UnsignedWord getImageHeapSizeInFile() {
         Word imageHeapBegin = IMAGE_HEAP_BEGIN.get();
         return IMAGE_HEAP_END.get().subtract(imageHeapBegin);
     }

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedRuntimeCodeInstaller.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedRuntimeCodeInstaller.java
@@ -146,7 +146,7 @@ public final class IsolatedRuntimeCodeInstaller extends RuntimeCodeInstaller {
     protected Pointer allocateCodeMemory(long size) {
         PointerBase memory = allocateCodeMemory0(targetIsolate, WordFactory.unsigned(size));
         if (memory.isNull()) {
-            throw new OutOfMemoryError();
+            throw new OutOfMemoryError("Could not allocate memory for runtime-compiled code.");
         }
         return (Pointer) memory;
     }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10072
- commit_1: "Better messages for OutOfMemoryErrors. Other small fixes and cleanups."

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 
- substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
- substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
- substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/CEntryPointSnippets.java
- substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractImageHeapProvider.java
- substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/ChunkBasedCommittedMemoryProvider.java

<details>

substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
- Context change: in graalvm-community-jdk21u the code is not under if().
- Applied the local change only, not considering the context.
```
<<<<<<< HEAD
            if (PhysicalMemory.isInitialized()) {
                UnsignedWord physicalMemorySize = PhysicalMemory.getCachedSize();
                int maximumHeapSizePercent = HeapParameters.getMaximumHeapSizePercent();
                /* Do not cache because `-Xmx` option parsing may not have happened yet. */
                UnsignedWord result = physicalMemorySize.unsignedDivide(100).multiply(maximumHeapSizePercent);
                if (result.belowThan(addressSpaceSize)) {
                    return result;
                }
            }
            return addressSpaceSize;
=======
            UnsignedWord physicalMemorySize = PhysicalMemory.size();
            int maximumHeapSizePercent = HeapParameters.getMaximumHeapSizePercent();
            /* Do not cache because `-Xmx` option parsing may not have happened yet. */
            UnsignedWord result = physicalMemorySize.unsignedDivide(100).multiply(maximumHeapSizePercent);
            return UnsignedUtils.min(result, addressSpaceSize);
>>>>>>> 7114e12d581 (Better messages for OutOfMemoryErrors.)
```

substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
- the change (get rid of getOptions0) is applicable after "Refactor the IsolateArgumentParser" only: https://github.com/oracle/graal/commit/020757d45958
- solution: mimic the code with OPTIONS variable that was replaced with getOptions on mainline: https://github.com/oracle/graal/commit/f32f2ee9ad89019658e2d7251b231c7974be6a1c
```
<<<<<<< HEAD
        for (int i = 0; i < OPTIONS.length; i++) {
            if (OPTIONS[i] == key) {
=======
        RuntimeOptionKey<?>[] options = getOptions();
        for (int i = 0; i < options.length; i++) {
            if (options[i] == key) {
>>>>>>> 7114e12d581 (Better messages for OutOfMemoryErrors.)
```

substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
- getParsedArgsSize() gets static modifier
- skipped: not applicable as graalvm-community-jdk21u still uses getParsedArgsSize() which is static
```
<<<<<<< HEAD
    public static int getStructSize() {
        return Long.BYTES * OPTION_COUNT;
=======
    public static int getParsedArgsSize() {
        return Long.BYTES * getOptionCount();
>>>>>>> 7114e12d581 (Better messages for OutOfMemoryErrors.)
```

substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/CEntryPointSnippets.java
- skipped the change: replace singleton call to a static getParsedArgsSize() call is not applicable because
- actual CEntryPointSnippets.createIsolate() calls a static IsolateArgumentParser.getParsedArgsSize() method without any singleton
```
<<<<<<< HEAD
        CLongPointer parsedArgs = StackValue.get(IsolateArgumentParser.getStructSize());
        IsolateArgumentParser.parse(parameters, parsedArgs);
        if (parameters.reservedSpaceSize().equal(0)) {
            parameters.setReservedSpaceSize(WordFactory.unsigned(parsedArgs.read(IsolateArgumentParser.getOptionIndex(SubstrateGCOptions.ReservedAddressSpaceSize))));
        }
=======

        IsolateArguments arguments = StackValue.get(IsolateArguments.class);
        UnmanagedMemoryUtil.fill((Pointer) arguments, SizeOf.unsigned(IsolateArguments.class), (byte) 0);
        CLongPointer parsedArgs = StackValue.get(IsolateArgumentParser.getParsedArgsSize());
        arguments.setParsedArgs(parsedArgs);

        IsolateArgumentParser.singleton().parse(parameters, arguments);

        Container.initialize();
>>>>>>> 7114e12d581 (Better messages for OutOfMemoryErrors.)
```

substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractImageHeapProvider.java
- different context, another implementation
- apply manually the simple change: protected->public access modifier
```
<<<<<<< HEAD
    protected static UnsignedWord getImageHeapSizeInFile() {
        Word imageHeapBegin = IMAGE_HEAP_BEGIN.get();
        return IMAGE_HEAP_END.get().subtract(imageHeapBegin);
=======
    public static UnsignedWord getImageHeapSizeInFile() {
        return getImageHeapSizeInFile(IMAGE_HEAP_BEGIN.get(), IMAGE_HEAP_END.get());
    }

    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
    protected static Pointer getImageHeapBegin(Pointer heapBase) {
        return heapBase.add(Heap.getHeap().getImageHeapOffsetInAddressSpace());
    }

    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
    protected static UnsignedWord getPreHeapAlignedSizeForDynamicMethodAddressResolver() {
        UnsignedWord requiredPreHeapMemoryInBytes = DynamicMethodAddressResolutionHeapSupport.get().getRequiredPreHeapMemoryInBytes();
        /* Ensure there is enough space to properly align the heap */
        UnsignedWord heapAlignment = WordFactory.unsigned(Heap.getHeap().getPreferredAddressSpaceAlignment());
        return roundUp((PointerBase) requiredPreHeapMemoryInBytes, heapAlignment);
>>>>>>> 7114e12d581 (Better messages for OutOfMemoryErrors.)
```

substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/ChunkBasedCommittedMemoryProvider.java
- simple conflict: just remove the extra NmtCategory.JavaHeap parameter specific for the mainline only
```
<<<<<<< HEAD
        return allocate(nbytes, alignment, false);
    }

    public Pointer allocateUnalignedChunk(UnsignedWord nbytes) {
        return allocate(nbytes, getAlignmentForUnalignedChunks(), false);
=======
        Pointer result = allocate(nbytes, alignment, false, NmtCategory.JavaHeap);
        if (result.isNull()) {
            throw ALIGNED_OUT_OF_MEMORY_ERROR;
        }
        return result;
    }

    public Pointer allocateUnalignedChunk(UnsignedWord nbytes) {
        Pointer result = allocate(nbytes, getAlignmentForUnalignedChunks(), false, NmtCategory.JavaHeap);
        if (result.isNull()) {
            throw UNALIGNED_OUT_OF_MEMORY_ERROR;
        }
        return result;
>>>>>>> 7114e12d581 (Better messages for OutOfMemoryErrors.)
```
</details>

<!-- Add the backport issue that this PR closes -->
Closes: none
It is a part of [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)