### PR TITLE
[Backport][GR-58571] Preserve local symbols if post-link stripping follows.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -749,12 +749,8 @@ public class SubstrateOptions {
     public static final HostedOptionKey<Integer> GenerateDebugInfo = new HostedOptionKey<>(0, SubstrateOptions::validateGenerateDebugInfo) {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Integer oldValue, Integer newValue) {
-            if (!OS.DARWIN.isCurrent()) {
-                /*
-                 * Keep the symbol table, as it may be used by debugging or profiling tools (e.g.,
-                 * perf). On Windows, the symbol table is included in the pdb-file, while on Linux,
-                 * it is part of the .debug file.
-                 */
+            if (OS.WINDOWS.isCurrent()) {
+                /* Keep symbols on Windows. The symbol table is part of the pdb-file. */
                 DeleteLocalSymbols.update(values, newValue == 0);
             }
         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java
@@ -289,7 +289,7 @@ public abstract class CCLinkerInvocation implements LinkerInvocation {
 
             additionalPreOptions.addAll(HostedLibCBase.singleton().getAdditionalLinkerOptions(imageKind));
 
-            if (SubstrateOptions.DeleteLocalSymbols.getValue()) {
+            if (SubstrateOptions.DeleteLocalSymbols.getValue() && !SubstrateOptions.StripDebugInfo.getValue()) {
                 additionalPreOptions.add("-Wl,-x");
             }
         }
@@ -396,7 +396,7 @@ public abstract class CCLinkerInvocation implements LinkerInvocation {
                 VMError.shouldNotReachHere(e);
             }
 
-            if (SubstrateOptions.DeleteLocalSymbols.getValue()) {
+            if (SubstrateOptions.DeleteLocalSymbols.getValue() && !SubstrateOptions.StripDebugInfo.getValue()) {
                 additionalPreOptions.add("-Wl,-x");
             }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoStripFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoStripFeature.java
@@ -25,7 +25,6 @@
 package com.oracle.svm.hosted.image;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.graalvm.compiler.core.common.SuppressFBWarnings;
@@ -114,19 +113,18 @@ public class NativeImageDebugInfoStripFeature implements InternalFeature {
                     BuildArtifacts.singleton().add(ArtifactType.DEBUG_INFO, debugInfoFilePath);
                     FileUtils.executeCommand(objcopyExe, "--add-gnu-debuglink=" + debugInfoFilePath, imageFilePath);
                 }
-                Path exportedSymbolsPath = createKeepSymbolsListFile(accessImpl);
-                FileUtils.executeCommand(objcopyExe, "--strip-all", "--keep-symbols=" + exportedSymbolsPath, imageFilePath);
+                if (SubstrateOptions.DeleteLocalSymbols.getValue()) {
+                    /* Strip debug info and local symbols. */
+                    FileUtils.executeCommand(objcopyExe, "--strip-all", imageFilePath);
+                } else {
+                    /* Strip debug info only. */
+                    FileUtils.executeCommand(objcopyExe, "--strip-debug", imageFilePath);
+                }
             } catch (IOException e) {
                 throw UserError.abort("Generation of separate debuginfo file failed", e);
             } catch (InterruptedException e) {
                 throw new InterruptImageBuilding("Interrupted during debuginfo file splitting of image " + imageName);
             }
         }
-    }
-
-    private static Path createKeepSymbolsListFile(AfterImageWriteAccessImpl accessImpl) throws IOException {
-        Path exportedSymbolsPath = accessImpl.getTempDirectory().resolve("keep-symbols.list").toAbsolutePath();
-        Files.write(exportedSymbolsPath, accessImpl.getImageSymbols(true));
-        return exportedSymbolsPath;
     }
 }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/9888

**Conflicts:** Minor conflict: a difference in a deleted code. <details>

```
<<<<<<< HEAD

    private static Path createKeepSymbolsListFile(AfterImageWriteAccessImpl accessImpl) throws IOException {
        Path exportedSymbolsPath = accessImpl.getTempDirectory().resolve("keep-symbols.list").toAbsolutePath();
        Files.write(exportedSymbolsPath, accessImpl.getImageSymbols(true));
        return exportedSymbolsPath;
    }
=======
>>>>>>> 2784e64ca29 (Preserve local symbols if post-link stripping follows)
```
</details>

<!-- Add the backport issue that this PR closes -->

**Closes: none**
It is a part of [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)