### PR TITLE
[Backport] Adapt JDK-8347564: ZGC: Crash in DependencyContext::clean_unloading_dependents

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u8OrEarlier.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u8OrEarlier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+
+public class JDK21u8OrEarlier implements BooleanSupplier {
+
+    public static final boolean jdk21u8OrEarlier = JavaVersionUtil.JAVA_SPEC < 21 ||
+                    (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() <= 8);
+
+    @Override
+    public boolean getAsBoolean() {
+        return jdk21u8OrEarlier;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/methodhandles/Target_java_lang_invoke_MethodHandleNatives.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/methodhandles/Target_java_lang_invoke_MethodHandleNatives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ import com.oracle.svm.core.annotate.TargetElement;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.invoke.Target_java_lang_invoke_MemberName;
 import com.oracle.svm.core.jdk.JDK20OrEarlier;
+import com.oracle.svm.core.jdk.JDK21u8OrEarlier;
 import com.oracle.svm.core.reflect.target.Target_java_lang_reflect_Field;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.util.ReflectionUtil;
@@ -196,6 +197,7 @@ final class Target_java_lang_invoke_MethodHandleNatives {
     private static native void copyOutBootstrapArguments(Class<?> caller, int[] indexInfo, int start, int end, Object[] buf, int pos, boolean resolve, Object ifNotAvailable);
 
     @Substitute
+    @TargetElement(onlyWith = JDK21u8OrEarlier.class)
     private static void clearCallSiteContext(Target_java_lang_invoke_MethodHandleNatives_CallSiteContext context) {
         throw unimplemented("CallSiteContext not supported");
     }
@@ -395,6 +397,6 @@ final class Target_java_lang_invoke_MethodHandleNatives_Constants {
     // Checkstyle: resume
 }
 
-@TargetClass(className = "java.lang.invoke.MethodHandleNatives", innerClass = "CallSiteContext")
+@TargetClass(className = "java.lang.invoke.MethodHandleNatives", innerClass = "CallSiteContext", onlyWith = JDK21u8OrEarlier.class)
 final class Target_java_lang_invoke_MethodHandleNatives_CallSiteContext {
 }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/commit/d9a3a5ab51357aaf4e21c785027a1bf84e2c91ff 
- Adds the required boolean supplier for dealing with the substitution on older JDK 21 releases.

**Conflicts:**
There were conflicts in the imports which I've resolved manually. Besides, this largely is a copy of https://github.com/oracle/graal/commit/d9a3a5ab51357aaf4e21c785027a1bf84e2c91ff but adapted to apply the substitution only for JDK `21.0.8` and earlier. Therefore, the need for the new class.

CI should be green with this and resolves also the build failure mentioned in #157.

Closes: #159 
