### PR TITLE
[Backport][GR-57835] Remove dead threads from PolyglotContextImpl#threads during new thread initialization.

### DIFF
--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextImpl.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextImpl.java
@@ -881,6 +881,14 @@ final class PolyglotContextImpl implements com.oracle.truffle.polyglot.PolyglotI
                          */
                         setCachedThreadInfo(PolyglotThreadInfo.NULL);
                     }
+                    if (needsInitialization) {
+                        /*
+                         * A thread is added to the threads map only by the thread itself, so when
+                         * the thread is in the map, and it is not alive, then it surely won't be
+                         * used ever again.
+                         */
+                        threads.entrySet().removeIf(threadInfoEntry -> !threadInfoEntry.getKey().isAlive());
+                    }
                     boolean transitionToMultiThreading = isSingleThreaded() && hasActiveOtherThread(true, false);
 
                     if (transitionToMultiThreading) {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/9623

**Conflicts:** There were no conflicts.

**Closes:** none
It is a part of [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)