### PR TITLE
[Backport][GR-60694] Fix int overflow in ObjectSizeCalculator#increaseByArraySize.

### DIFF
--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/ObjectSizeCalculator.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/ObjectSizeCalculator.java
@@ -188,8 +188,8 @@ final class ObjectSizeCalculator {
 
     /**
      * Given an object, returns the allocated size, in bytes, of the object and all other objects
-     * reachable from it within {@link ObjectSizeCalculator#isContextHeapBoundary(Object) context
-     * heap boundary}.
+     * reachable from it within {@link ObjectSizeCalculator#isContextHeapBoundary(APIAccess, Object)
+     * context heap boundary}.
      *
      * @param obj the object; cannot be null.
      * @param stopAtBytes when calculated size exceeds stopAtBytes, calculation stops and returns
@@ -285,7 +285,7 @@ final class ObjectSizeCalculator {
         }
     }
 
-    private static void increaseByArraySize(CalculationState calculationState, ArrayMemoryLayout layout, int length) {
+    private static void increaseByArraySize(CalculationState calculationState, ArrayMemoryLayout layout, long length) {
         increaseSize(calculationState, roundToObjectAlignment(layout.baseOffset + length * layout.indexScale, getObjectAlignment()));
     }
 


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10374

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

**Closes:** none
It is a part of [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)