### PR TITLE
[Backport][GR-56094] Remove constant memory buffer assumption and simplify ByteArrayWasmMemory.

### DIFF
--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/BinaryParser.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/BinaryParser.java
@@ -1033,7 +1033,7 @@ public class BinaryParser extends BinaryStreamParser {
             // Do not override the code entry offset when rereading the function.
             module.setCodeEntryOffset(codeEntryIndex, bytecodeEndOffset);
         }
-        return new CodeEntry(functionIndex, state.maxStackSize(), locals, resultTypes, callNodes, bytecodeStartOffset, bytecodeEndOffset);
+        return new CodeEntry(functionIndex, state.maxStackSize(), locals, resultTypes, callNodes, bytecodeStartOffset, bytecodeEndOffset, state.usesMemoryZero());
     }
 
     private void readNumericInstructions(ParserState state, int opcode) {

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/SymbolTable.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/SymbolTable.java
@@ -179,12 +179,12 @@ public abstract class SymbolTable {
 
     public static class MemoryInfo {
         /**
-         * Lower bound on memory size.
+         * Lower bound on memory size (in pages of 64 kiB).
          */
         public final long initialSize;
 
         /**
-         * Upper bound on memory size.
+         * Upper bound on memory size (in pages of 64 kiB).
          * <p>
          * <em>Note:</em> this is the upper bound defined by the module. A memory instance might
          * have a lower internal max allowed size in practice.

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmCodeEntry.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmCodeEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -52,14 +52,16 @@ public final class WasmCodeEntry {
     private final BranchProfile errorBranch = BranchProfile.create();
     private final int numLocals;
     private final int resultCount;
+    private final boolean usesMemoryZero;
 
-    public WasmCodeEntry(WasmFunction function, byte[] bytecode, byte[] localTypes, byte[] resultTypes) {
+    public WasmCodeEntry(WasmFunction function, byte[] bytecode, byte[] localTypes, byte[] resultTypes, boolean usesMemoryZero) {
         this.function = function;
         this.bytecode = bytecode;
         this.localTypes = localTypes;
         this.numLocals = localTypes.length;
         this.resultTypes = resultTypes;
         this.resultCount = resultTypes.length;
+        this.usesMemoryZero = usesMemoryZero;
     }
 
     public WasmFunction function() {
@@ -92,6 +94,10 @@ public final class WasmCodeEntry {
 
     public void errorBranch() {
         errorBranch.enter();
+    }
+
+    public boolean usesMemoryZero() {
+        return usesMemoryZero;
     }
 
     @Override

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmInstantiator.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmInstantiator.java
@@ -495,7 +495,7 @@ public class WasmInstantiator {
             assert context.language().isMultiContext();
             return cachedTarget;
         }
-        final WasmCodeEntry wasmCodeEntry = new WasmCodeEntry(function, module.bytecode(), codeEntry.localTypes(), codeEntry.resultTypes());
+        final WasmCodeEntry wasmCodeEntry = new WasmCodeEntry(function, module.bytecode(), codeEntry.localTypes(), codeEntry.resultTypes(), codeEntry.usesMemoryZero());
         final FrameDescriptor frameDescriptor = createFrameDescriptor(codeEntry.localTypes(), codeEntry.maxStackSize());
         final WasmInstrumentableFunctionNode functionNode = instantiateFunctionNode(module, instance, wasmCodeEntry, codeEntry);
         final WasmRootNode rootNode;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/NativeWasmMemory.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/NativeWasmMemory.java
@@ -127,6 +127,7 @@ final class NativeWasmMemory extends WasmMemory {
     }
 
     @Override
+    @TruffleBoundary
     public void reset() {
         free();
         size = declaredMinSize;
@@ -953,6 +954,7 @@ final class NativeWasmMemory extends WasmMemory {
         return startAddress == 0;
     }
 
+    @TruffleBoundary
     private void free() {
         unsafe.freeMemory(startAddress);
         startAddress = 0;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/UnsafeWasmMemory.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/UnsafeWasmMemory.java
@@ -119,6 +119,7 @@ public final class UnsafeWasmMemory extends WasmMemory {
     }
 
     @Override
+    @TruffleBoundary
     public void reset() {
         size = declaredMinSize;
         buffer = allocateBuffer(byteSize());

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/WasmMemory.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/WasmMemory.java
@@ -876,6 +876,13 @@ public abstract class WasmMemory extends EmbedderDataHolder implements TruffleOb
         return length < 0 || offset < 0 || offset > getBufferSize() - length;
     }
 
+    public final WasmMemory checkSize(long initialSize) {
+        if (byteSize() < initialSize * Sizes.MEMORY_PAGE_SIZE) {
+            throw CompilerDirectives.shouldNotReachHere("Memory size must not be less than initial size");
+        }
+        return this;
+    }
+
     /**
      * Copy data from an input stream into memory.
      *

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
@@ -272,7 +272,7 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
         int line = startLine;
 
         // Note: The module may not have any memories.
-        final WasmMemory zeroMemory = module.memoryCount() == 0 ? null : memory0(instance);
+        final WasmMemory zeroMemory = !codeEntry.usesMemoryZero() ? null : memory0(instance);
 
         check(bytecode.length, (1 << 31) - 1);
 

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
@@ -185,8 +185,8 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
         this.notifyFunction = notifyFunction;
     }
 
-    private WasmMemory memory(WasmInstance instance) {
-        return memory(instance, 0);
+    private WasmMemory memory0(WasmInstance instance) {
+        return memory(instance, 0).checkSize(module.memoryInitialSize(0));
     }
 
     private WasmMemory memory(WasmInstance instance, int index) {
@@ -272,7 +272,7 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
         int line = startLine;
 
         // Note: The module may not have any memories.
-        final WasmMemory zeroMemory = module.memoryCount() == 0 ? null : memory(instance);
+        final WasmMemory zeroMemory = module.memoryCount() == 0 ? null : memory0(instance);
 
         check(bytecode.length, (1 << 31) - 1);
 

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmFunctionNode.java
@@ -4644,31 +4644,31 @@ public final class WasmFunctionNode extends Node implements BytecodeOSRNode {
         int f = rawPeekU8(data, profileOffset + 1);
         boolean val = condition;
         if (val) {
+            if (t == 0) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+            }
             if (!CompilerDirectives.inInterpreter()) {
-                if (t == 0) {
-                    CompilerDirectives.transferToInterpreterAndInvalidate();
-                }
                 if (f == 0) {
                     // Make this branch fold during PE
                     val = true;
                 }
             } else {
                 if (t < MAX_PROFILE_VALUE) {
-                    data[profileOffset]++;
+                    data[profileOffset] = (byte) (t + 1);
                 }
             }
         } else {
+            if (f == 0) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+            }
             if (!CompilerDirectives.inInterpreter()) {
-                if (f == 0) {
-                    CompilerDirectives.transferToInterpreterAndInvalidate();
-                }
                 if (t == 0) {
                     // Make this branch fold during PE
                     val = false;
                 }
             } else {
                 if (f < MAX_PROFILE_VALUE) {
-                    data[profileOffset + 1]++;
+                    data[profileOffset + 1] = (byte) (f + 1);
                 }
             }
         }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/bytecode/BytecodeParser.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/bytecode/BytecodeParser.java
@@ -423,7 +423,8 @@ public abstract class BytecodeParser {
             results = Bytecode.EMPTY_BYTES;
         }
         List<CallNode> callNodes = readCallNodes(bytecode, codeEntryOffset - length, codeEntryOffset);
-        return new CodeEntry(functionIndex, maxStackSize, locals, results, callNodes, codeEntryOffset - length, codeEntryOffset);
+        boolean usesMemoryZero = module.memoryCount() != 0;
+        return new CodeEntry(functionIndex, maxStackSize, locals, results, callNodes, codeEntryOffset - length, codeEntryOffset, usesMemoryZero);
     }
 
     /**

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/ir/CodeEntry.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/ir/CodeEntry.java
@@ -54,8 +54,9 @@ public final class CodeEntry {
     private final List<CallNode> callNodes;
     private final int bytecodeStartOffset;
     private final int bytecodeEndOffset;
+    private final boolean usesMemoryZero;
 
-    public CodeEntry(int functionIndex, int maxStackSize, byte[] localTypes, byte[] resultTypes, List<CallNode> callNodes, int startOffset, int endOffset) {
+    public CodeEntry(int functionIndex, int maxStackSize, byte[] localTypes, byte[] resultTypes, List<CallNode> callNodes, int startOffset, int endOffset, boolean usesMemoryZero) {
         this.functionIndex = functionIndex;
         this.maxStackSize = maxStackSize;
         this.localTypes = localTypes;
@@ -63,6 +64,7 @@ public final class CodeEntry {
         this.callNodes = callNodes;
         this.bytecodeStartOffset = startOffset;
         this.bytecodeEndOffset = endOffset;
+        this.usesMemoryZero = usesMemoryZero;
     }
 
     public int maxStackSize() {
@@ -91,5 +93,9 @@ public final class CodeEntry {
 
     public int bytecodeEndOffset() {
         return bytecodeEndOffset;
+    }
+
+    public boolean usesMemoryZero() {
+        return usesMemoryZero;
     }
 }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/validation/ParserState.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/parser/validation/ParserState.java
@@ -65,6 +65,7 @@ public class ParserState {
     private final RuntimeBytecodeGen bytecode;
 
     private int maxStackSize;
+    private boolean usesMemoryZero;
 
     public ParserState(RuntimeBytecodeGen bytecode) {
         this.valueStack = new ByteArrayList();
@@ -76,7 +77,7 @@ public class ParserState {
 
     /**
      * Pops a value from the stack if possible. Throws an error on stack underflow.
-     * 
+     *
      * @param expectedValueType The expectedValueType used for error generation.
      * @return The top of the stack or -1.
      */
@@ -101,7 +102,7 @@ public class ParserState {
      * are returned. If the number of values on the stack is greater or equal to the number of
      * expectedValueTypes, the values equal to the number of expectedValueTypes is popped from the
      * stack.
-     * 
+     *
      * @param expectedValueTypes Value types expected on the stack.
      * @return The maximum of available stack values smaller than the length of expectedValueTypes.
      */
@@ -117,7 +118,7 @@ public class ParserState {
 
     /**
      * Pops the maximum available values from the current stack frame.
-     * 
+     *
      * @return The maximum of available stack values.
      */
     private byte[] popAvailableUnchecked() {
@@ -133,7 +134,7 @@ public class ParserState {
 
     /**
      * Checks if two sets of value types are equivalent.
-     * 
+     *
      * @param expectedTypes The expected value types.
      * @param actualTypes The actual value types.
      * @return True if both are equivalent.
@@ -155,7 +156,7 @@ public class ParserState {
 
     /**
      * Pushes a value type onto the stack.
-     * 
+     *
      * @param valueType The value type that should be added.
      */
     public void push(byte valueType) {
@@ -165,7 +166,7 @@ public class ParserState {
 
     /**
      * Pushes all provided value types onto the stack.
-     * 
+     *
      * @param valueTypes The value types that should be added.
      */
     public void pushAll(byte[] valueTypes) {
@@ -176,7 +177,7 @@ public class ParserState {
 
     /**
      * Pops the topmost value type from the stack. Throws an error if the stack is empty.
-     * 
+     *
      * @return The value type on top of the stack or -1.
      * @throws WasmException If the stack is empty.
      */
@@ -186,7 +187,7 @@ public class ParserState {
 
     /**
      * Pops the topmost value type from the stack and checks if it is equivalent to the given value.
-     * 
+     *
      * @param expectedValueType The expected value type.
      * @return The value type on top of the stack.
      * @throws WasmException If the stack is empty or the value types do not match.
@@ -220,7 +221,7 @@ public class ParserState {
     /**
      * Pops the topmost value types from the stack and checks if they are equivalent to the given
      * set of value types.
-     * 
+     *
      * @param expectedValueTypes The expected value types.
      * @return The value types on top of the stack.
      * @throws WasmException If the stack is empty or the value types do not match.
@@ -335,7 +336,7 @@ public class ParserState {
     /**
      * Performs the necessary branch checks and adds the unconditional branch information to the
      * extra data array.
-     * 
+     *
      * @param branchLabel The target label.
      */
     public void addUnconditionalBranch(int branchLabel) {
@@ -349,7 +350,7 @@ public class ParserState {
     /**
      * Performs the necessary branch checks and adds the branch table information to the extra data
      * array.
-     * 
+     *
      * @param branchLabels The target labels.
      */
     public void addBranchTable(int[] branchLabels) {
@@ -371,7 +372,7 @@ public class ParserState {
 
     /**
      * Performs the necessary checks for a function return.
-     * 
+     *
      * @param multiValue If multiple return values are supported.
      */
     public void addReturn(boolean multiValue) {
@@ -386,7 +387,7 @@ public class ParserState {
 
     /**
      * Adds the index of an indirect call node to the extra data array.
-     * 
+     *
      * @param nodeIndex The index of the indirect call.
      */
     public void addIndirectCall(int nodeIndex, int typeIndex, int tableIndex) {
@@ -395,7 +396,7 @@ public class ParserState {
 
     /**
      * Adds the index of a direct call node to the extra data array.
-     * 
+     *
      * @param nodeIndex The index of the direct call.
      */
     public void addCall(int nodeIndex, int functionIndex) {
@@ -425,7 +426,7 @@ public class ParserState {
 
     /**
      * Adds the given instruction and an i32 immediate value to the bytecode.
-     * 
+     *
      * @param instruction The instruction
      * @param value The immediate value
      */
@@ -435,7 +436,7 @@ public class ParserState {
 
     /**
      * Adds the given instruction and an i64 immediate value to the bytecode.
-     * 
+     *
      * @param instruction The instruction
      * @param value The immediate value
      */
@@ -455,7 +456,7 @@ public class ParserState {
 
     /**
      * Adds the given instruction and two i32 immediate values to the bytecode.
-     * 
+     *
      * @param instruction The instruction
      * @param value1 The first immediate value
      * @param value2 The second immediate value
@@ -468,7 +469,7 @@ public class ParserState {
      * Adds the i8 or i32 version of the given instruction to the bytecode based on the given
      * immediate value. If the value fits into a signed i8 value, the i8 instruction and an i8 value
      * are added. Otherwise, the i32 instruction and an i32 value are added.
-     * 
+     *
      * @param instruction The i8 version of the instruction
      * @param value The immediate value.
      */
@@ -480,7 +481,7 @@ public class ParserState {
      * Adds the i8 or i64 version of the given instruction to the bytecode based on the given
      * immediate value. If the value fits into a signed i8 value, the i8 instruction and an i8 value
      * are added. Otherwise, the i64 instruction and i64 value are added.
-     * 
+     *
      * @param instruction The i8 version of the instruction
      * @param value The immediate value
      */
@@ -492,7 +493,7 @@ public class ParserState {
      * Adds the u8 or i32 version of the given instruction to the bytecode based on the given
      * immediate value. If the value fits into a u8 value, the u8 instruction and a u8 value are
      * added. Otherwise, the i32 instruction and an i32 value are added.
-     * 
+     *
      * @param instruction The u8 version of the instruction
      * @param value The immediate value
      */
@@ -502,13 +503,14 @@ public class ParserState {
 
     /**
      * Adds a memory instruction based on the given values and index type.
-     * 
+     *
      * @param baseInstruction The base version of the memory instruction
      * @param memoryIndex The index of the memory being accessed
      * @param value The immediate value
      * @param indexType64 If the index type is 64 bit.
      */
     public void addMemoryInstruction(int baseInstruction, int memoryIndex, long value, boolean indexType64) {
+        markMemoryUsed(memoryIndex);
         bytecode.addMemoryInstruction(baseInstruction, baseInstruction + 1, baseInstruction + 2, memoryIndex, value, indexType64);
     }
 
@@ -522,6 +524,7 @@ public class ParserState {
      * @param indexType64 If the index type is 64 bit.
      */
     public void addExtendedMemoryInstruction(int instruction, int memoryIndex, long value, boolean indexType64) {
+        markMemoryUsed(memoryIndex);
         bytecode.addExtendedMemoryInstruction(instruction, memoryIndex, value, indexType64);
     }
 
@@ -535,13 +538,14 @@ public class ParserState {
      * @param laneIndex The lane index
      */
     public void addVectorMemoryLaneInstruction(int instruction, int memoryIndex, long value, boolean indexType64, byte laneIndex) {
+        markMemoryUsed(memoryIndex);
         bytecode.addExtendedMemoryInstruction(instruction, memoryIndex, value, indexType64);
         bytecode.add(laneIndex);
     }
 
     /**
      * Adds a lane-indexed vector instruction (extract_lane or replace_lane).
-     * 
+     *
      * @param instruction The vector instruction
      * @param laneIndex The lane index
      */
@@ -554,7 +558,7 @@ public class ParserState {
      * Finishes the current control frame and removes it from the control frame stack.
      *
      * @param multiValue If multiple return values are supported.
-     * 
+     *
      * @throws WasmException If the number of return value types do not match with the remaining
      *             stack or the number of return values is greater than 1.
      */
@@ -576,7 +580,7 @@ public class ParserState {
 
     /**
      * Checks that the expected return types are actually on the value stack.
-     * 
+     *
      * @param frame The frame that is exited.
      * @param resultTypes The expected return types of the frame.
      */
@@ -627,7 +631,7 @@ public class ParserState {
 
     /**
      * Checks if the given parameter value types do match the current value types on the stack.
-     * 
+     *
      * @param paramTypes The expected value types.
      * @throws WasmException If the parameter value types and the vale types on the stack do not
      *             match.
@@ -645,7 +649,7 @@ public class ParserState {
 
     /**
      * Checks if the given label is a valid jump target.
-     * 
+     *
      * @param label The label which to jump to.
      * @throws WasmException If the label is out or reach.
      */
@@ -657,7 +661,7 @@ public class ParserState {
 
     /**
      * Checks if the value types of two different labels match.
-     * 
+     *
      * @param expectedTypes The expected value types.
      * @param actualTypes The value types that should be checked.
      * @throws WasmException If the provided sets of value types do not match.
@@ -670,7 +674,7 @@ public class ParserState {
 
     /**
      * Checks if the given function type is within range.
-     * 
+     *
      * @param typeIndex The function type.
      * @param max The number of available function types.
      * @throws WasmException If the given function type is greater or equal to the given maximum.
@@ -700,5 +704,15 @@ public class ParserState {
 
     public int maxStackSize() {
         return maxStackSize;
+    }
+
+    private void markMemoryUsed(int memoryIndex) {
+        if (memoryIndex == 0) {
+            usesMemoryZero = true;
+        }
+    }
+
+    public boolean usesMemoryZero() {
+        return usesMemoryZero;
     }
 }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/9457
-- **Excluding** https://github.com/oracle/graal/commit/a6fa57bc4d9fc68631d3dcfff6330b43c03ce9e3


<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

**Issues:**
The Oracle GraalVM for JDK 21.0.6 backports log entry `"Remove constant memory buffer assumption"` only corresponds to the first commit `"Remove constant memory buffer assumption and simplify ByteArrayWasmMemory."` Backporting the other changes in [GR-56094 PR#9457](https://github.com/oracle/graal/pull/9457) is questionable:
- Remove constant memory buffer assumption and simplify ByteArrayWasmMemory.
- Check that memory 0 size >= initial size at the start of a wasm function.
This allows hoisting bounds checks for memory accesses that are guaranteed to stay within the initial bounds
- Only perform initial memory 0 bounds check if the wasm function uses memory 0.
- Work around for nullary benchmarkTeardownEach() in photon benchmark.
- Fix TraceTransferToInterpreter in WasmFunctionNode.profileCondition.
 - ~~Try to read WebAssembly.Module bytes via Buffer Interop.~~

The last change `"Try to read WebAssembly.Module bytes via Buffer Interop."` introduces a build error, likely due to a missing change from [[GR-49386] [GR-38404] Convert guest byte buffers to host byte array or ByteSequence](https://github.com/oracle/graal/pull/7870), we may need to skip this change:

<details>

```
/home/boris/graal-21/graal/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/api/WebAssembly.java:303: error: cannot find symbol
                    interop.readBuffer(source, 0, bytes, 0, (int) size);
                           ^
  symbol:   method readBuffer(Object,int,byte[],int,int)
  location: variable interop of type InteropLibrary
```
</details>


**Closes:** none
It is a part of [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)