### PR TITLE
[Backport][GR-59497] TRegex: fix OracleDB flavor incorrectly parsing escaped surrogate pairs.

### DIFF
--- a/regex/src/com.oracle.truffle.regex.test/src/com/oracle/truffle/regex/tregex/test/OracleDBTests.java
+++ b/regex/src/com.oracle.truffle.regex.test/src/com/oracle/truffle/regex/tregex/test/OracleDBTests.java
@@ -1387,6 +1387,7 @@ public class OracleDBTests extends RegexTestBase {
         test("()(a*\\1+)*", "", "aaa", 0, true, 0, 3, 0, 0, 3, 3);
         test("(a(\\2b|)?)+\\1c", "", "aaabaaac", 0, true, 0, 8, 5, 6, 6, 6);
         test("((|ab)+?w\\Z|^c)de()d", "", "ffffff", 0, false);
+        test("\u0282\\\ud807\udfdd+\u1cf2", "", "\u0282\ud807\udfdd\ud807\udfdd\u1cf2", 0, true, 0, 13);
         test("(a{1100,1100})\\1", "i", "a".repeat(2400), 0, true, 0, 2200, 0, 1100);
 
         /* GENERATED CODE END - KEEP THIS MARKER FOR AUTOMATIC UPDATES */

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/parser/flavors/OracleDBRegexLexer.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/parser/flavors/OracleDBRegexLexer.java
@@ -424,7 +424,7 @@ public final class OracleDBRegexLexer extends RegexLexer {
         } else {
             // outside character classes, all escaped characters are simply treated as literals,
             // there are no escape sequences in oracleDB
-            return c;
+            return Character.isHighSurrogate(c) ? finishSurrogatePair(c) : c;
         }
     }
 


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/9999

**Conflicts:** There were no conflicts.

**Closes:** none
It is a part of [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)
