### PR TITLE
[Backport][GR-53902] Fix DynamicObjectLibrary.setPropertyFlags.

### DIFF
--- a/truffle/src/com.oracle.truffle.object/src/com/oracle/truffle/object/DynamicObjectLibraryImpl.java
+++ b/truffle/src/com.oracle.truffle.object/src/com/oracle/truffle/object/DynamicObjectLibraryImpl.java
@@ -654,13 +654,13 @@ abstract class DynamicObjectLibraryImpl {
         @TruffleBoundary
         @Override
         public boolean setPropertyFlags(DynamicObject object, Shape cachedShape, Object key, int propertyFlags) {
+            updateShapeImpl(object);
             ShapeImpl oldShape = (ShapeImpl) ACCESS.getShape(object);
             Property existingProperty = oldShape.getProperty(key);
             if (existingProperty == null) {
                 return false;
             }
             if (existingProperty.getFlags() != propertyFlags) {
-                updateShapeImpl(object);
                 Shape newShape = changePropertyFlags(oldShape, (PropertyImpl) existingProperty, propertyFlags);
                 if (newShape != oldShape) {
                     ACCESS.setShape(object, newShape);

--- a/truffle/src/com.oracle.truffle.object/src/com/oracle/truffle/object/TrieNode.java
+++ b/truffle/src/com.oracle.truffle.object/src/com/oracle/truffle/object/TrieNode.java
@@ -62,7 +62,7 @@ abstract class TrieNode<K, V, E extends Map.Entry<K, V>> {
     }
 
     final TrieNode<K, V, E> put(K key, int hash, E entry) {
-        assert key != null && hash(key) == hash && key(entry).equals(key);
+        assert key != null && hash(key) == hash && key(entry).equals(key) : Arrays.asList(entry, key);
         return put(key, hash, entry, 0);
     }
 
@@ -205,7 +205,7 @@ abstract class TrieNode<K, V, E extends Map.Entry<K, V>> {
     }
 
     final TrieNode<K, V, E> combine(K key1, int hash1, E entry1, K key2, int hash2, E entry2, int shift) {
-        assert !key1.equals(key2);
+        assert !key1.equals(key2) : Arrays.asList(key1, key2);
         if (hash1 != hash2) {
             int pos1 = pos(hash1, shift);
             int pos2 = pos(hash2, shift);
@@ -388,7 +388,7 @@ abstract class TrieNode<K, V, E extends Map.Entry<K, V>> {
                 return null;
             } else {
                 E entry = (E) entries[index];
-                assert entry != null && key(entry).equals(key);
+                assert entry != null && key(entry).equals(key) : Arrays.asList(entry, key);
                 return entry;
             }
         }
@@ -402,7 +402,7 @@ abstract class TrieNode<K, V, E extends Map.Entry<K, V>> {
                     return new HashCollisionNode<>(hash, copyAndAppend(entries, entry));
                 } else {
                     E e = (E) entries[index];
-                    assert e != null && key(e).equals(key);
+                    assert e != null && key(e).equals(key) : Arrays.asList(e, key);
                     if (e.equals(entry)) {
                         return this;
                     } else {
@@ -421,7 +421,7 @@ abstract class TrieNode<K, V, E extends Map.Entry<K, V>> {
             if (index < 0) {
                 return this;
             } else {
-                assert entries[index] != null && key((E) entries[index]).equals(key);
+                assert entries[index] != null && key((E) entries[index]).equals(key) : Arrays.asList(entries[index], key);
                 assert entries.length >= 2;
                 if (entries.length == 2) {
                     return new BitmapNode<>(bit(this.hashcode, shift), copyAndRemove(entries, index));

--- a/truffle/src/com.oracle.truffle.object/src/com/oracle/truffle/object/TriePropertyMap.java
+++ b/truffle/src/com.oracle.truffle.object/src/com/oracle/truffle/object/TriePropertyMap.java
@@ -41,6 +41,7 @@
 package com.oracle.truffle.object;
 
 import java.util.AbstractSet;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -155,6 +156,7 @@ final class TriePropertyMap extends PropertyMap implements LinkedImmutableMap<Ob
     }
 
     private boolean verify() {
+        assert root != null;
         assert (size == 0 && head == null && tail == null) || (size != 0 && head != null && tail != null) : "size=" + size + ", head=" + head + ", tail=" + tail;
         assert head == null || head == getEntry(head.getKey());
         assert tail == null || tail == getEntry(tail.getKey());
@@ -211,7 +213,7 @@ final class TriePropertyMap extends PropertyMap implements LinkedImmutableMap<Ob
     @Override
     public LinkedPropertyEntry getEntry(Object key) {
         LinkedPropertyEntry entry = root.find(key, hash(key));
-        assert entry == null || entry.getKey().equals(key);
+        assert entry == null || entry.getKey().equals(key) : Arrays.asList(entry, key);
         return entry;
     }
 
@@ -268,17 +270,13 @@ final class TriePropertyMap extends PropertyMap implements LinkedImmutableMap<Ob
             newTail = tail;
 
             newEntry = existing.withValue(value);
-            assert !newEntry.equals(existing);
-            if (existing.getPrevKey() != null) {
-                assert getEntry(existing.getPrevKey()).getNextKey().equals(key);
-            } else {
-                assert existing == head;
+            assert !newEntry.equals(existing) : Arrays.asList(newEntry, existing);
+            if (existing.getPrevKey() == null) {
+                assert existing == head : Arrays.asList(existing, head);
                 newHead = newEntry;
             }
-            if (existing.getNextKey() != null) {
-                assert getEntry(existing.getNextKey()).getPrevKey().equals(key);
-            } else {
-                assert existing == tail;
+            if (existing.getNextKey() == null) {
+                assert existing == tail : Arrays.asList(existing, tail);
                 newTail = newEntry;
             }
         }
@@ -329,7 +327,6 @@ final class TriePropertyMap extends PropertyMap implements LinkedImmutableMap<Ob
             }
         }
         newRoot = newRoot.remove(key, hash);
-        assert newRoot != null;
         return new TriePropertyMap(size - 1, newRoot, newHead, newTail);
     }
 


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/8920

**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: (none)
It is a part of: [[Backport] Oracle GraalVM for JDK 21.0.6 backports and fixes](https://github.com/graalvm/graalvm-community-jdk21u/issues/64)