### PR TITLE
Add John Spurling as reviewer

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -26,4 +26,5 @@ Between step 1 and 3 no new pull requests should be merged.
 
 * [Boris Ulasevich](https://github.com/bulasevich)
 * [Cesar Soares](https://github.com/JohnTortugo)
+* [John Spurling](https://github.com/synecdoche)
 * [Volker Simonis](https://github.com/simonis/)


### PR DESCRIPTION
John has a track record of working on GraalVM in Twitter and is now part of the AWS JDK team and has already contributed some backports.

cc @synecdoche 