### PR TITLE
Update graal-js and graal-nodejs to GraalVM 23.1.8 (JDK 21.0.8)

### DIFF
--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -33,7 +33,7 @@ suite = {
                 "name": "graal-nodejs",
                 "subdir": True,
                 "dynamic": True,
-                "version": "11b33a178a9d9838783a5e03f6f3b3d9fea2b489",
+                "version": "5f294912081e699bc204b06a248e9d8b4a9c80ff",
                 "urls" : [
                     {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]
@@ -42,7 +42,7 @@ suite = {
                 "name": "graal-js",
                 "subdir": True,
                 "dynamic": True,
-                "version": "11b33a178a9d9838783a5e03f6f3b3d9fea2b489",
+                "version": "5f294912081e699bc204b06a248e9d8b4a9c80ff",
                 "urls": [
                     {"url": "https://github.com/graalvm/graaljs.git", "kind" : "git"},
                 ]


### PR DESCRIPTION
The update sets graal-js and graal-nodejs to graal-23.1.8 tag that includes GraalJS changes from [Oracle GraalVM for JDK 21.0.8 changelog](https://docs.oracle.com/en/graalvm/jdk/21/docs/release-notes/): 
- [GR-65310] Backport to 23.1: Dates with missing UTC offset should be interpreted (in nashorn-compat mode) as UTC time when they are "strict" only.
- [GR-64187] Backport to 23.1: Using latest double-conversion version 3.3.0.
- [GR-63246] Backport to 23.1: Fix ClassCastException in super property access.
- [GR-64709] Backport to 23.1: ExportValueNode.doTruffleObject() should exclude SafeIntegers.
- [GR-63059] Backport to 23.1: Map.prototype.forEach needs to import key and value of foreign hash entries.
- [GR-64697] Backport to 23.1: Correction of Array.prototype.flat() producing a foreign array.

graal-23.1.8 tag info:
https://github.com/oracle/graaljs/commits/graal-23.1.8

The change does not update Node.js version (still 18.20.6, see recent [[Backport][GR-61882] Upgrading the underlying Node.js to version 18.20.6.](https://github.com/graalvm/graalvm-community-jdk21u/pull/99) update).

Brings GraalJS changes mentioned in https://github.com/graalvm/graalvm-community-jdk21u/issues/64 and https://github.com/graalvm/graalvm-community-jdk21u/issues/66