### PR TITLE
[Backport] [Oracle GraalVM] [GR-65664] Backport to 23.1: Rethrow OutOfMemoryErrors that happen during performance data initialization.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jvmstat/PerfManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jvmstat/PerfManager.java
@@ -185,7 +185,6 @@ public class PerfManager {
         @Override
         public void run() {
             initializeMemory();
-
             try {
                 sampleData();
                 ImageSingletons.lookup(PerfMemory.class).setAccessible();
@@ -213,8 +212,11 @@ public class PerfManager {
 
                 initialized = true;
                 initializationCondition.broadcast();
+            } catch (OutOfMemoryError e) {
+                /* For now, we can only rethrow the error to terminate the thread (see GR-40601). */
+                throw e;
             } catch (Throwable e) {
-                VMError.shouldNotReachHere(ERROR_DURING_INITIALIZATION, e);
+                throw VMError.shouldNotReachHere(ERROR_DURING_INITIALIZATION, e);
             } finally {
                 initializationMutex.unlock();
             }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11345

**Conflicts:** There were no conflicts. but I it needed to be adapted to avoid using `RecurringCallbackSupport` which is not present since
https://github.com/oracle/graal/commit/0a37b5f5622d238a5540d8ef80773630985d31a5
is not backported

**Closes:** https://github.com/graalvm/graalvm-community-jdk21u/issues/179
