### PR TITLE
[Backport] [Oracle GraalVM] [GR-68114] Backport to 23.1: Fix memory leak in SourceManager.verifiedPaths.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
@@ -160,7 +160,7 @@ public class SourceManager {
      * A map from a Java type to an associated source paths which is known to have an up to date
      * entry in the relevant source file cache. This is used to memoize previous lookups.
      */
-    private static HashMap<ResolvedJavaType, Path> verifiedPaths = new HashMap<>();
+    private HashMap<ResolvedJavaType, Path> verifiedPaths = new HashMap<>();
 
     /**
      * An invalid path used as a marker to track failed lookups so we don't waste time looking up


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11794

**Conflicts:** 

```diff
diff --cc substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
index 6e5b030e025,f3d3e7c7a45..00000000000
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
@@@ -160,7 -159,7 +160,11 @@@ public class SourceManager 
       * A map from a Java type to an associated source paths which is known to have an up to date
       * entry in the relevant source file cache. This is used to memoize previous lookups.
       */
++<<<<<<< HEAD
 +    private static HashMap<ResolvedJavaType, Path> verifiedPaths = new HashMap<>();
++=======
+     private final ConcurrentHashMap<ResolvedJavaType, Path> verifiedPaths = new ConcurrentHashMap<>();
++>>>>>>> 1eb663808c9 (Fix memory leak in SourceManager.verifiedPaths.)
  
      /**
       * An invalid path used as a marker to track failed lookups so we don't waste time looking up
```

due to https://github.com/oracle/graal/commit/9205e31c2942b3bc9320c2fb2e29e6ed8c2552d6#diff-c396f1d9a2843b0f7407dab2971e8c994cc8743fcb0e0153e8a362b62712d896R162 not being backported.

Resolved by only removing the `static` qualifier.  

Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/186
