### PR TITLE
[Backport] [Oracle GraalVM] [GR-65853] Backport to 23.1: Return correct name for libgraal-specific collection policy.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
@@ -63,6 +63,11 @@ class LibGraalCollectionPolicy extends AdaptiveCollectionPolicy {
     private UnsignedWord sizeBefore = WordFactory.zero();
     private GCCause lastGCCause = null;
 
+    @Override
+    public String getName() {
+        return "libgraal";
+    }
+
     /**
      * The hinted GC will be triggered only if the used bytes in eden space is greater than
      * {@link Options#ExpectedEdenSize}, or if the ratio of used bytes to total allocated bytes of


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11392

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/180
