### PR TITLE
[Backport] [Oracle GraalVM] [GR-66289] Backport to 23.1: TruffleLogger.getLevelNum() causes deopt loops.

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/replacements/test/PEGraphDecoderTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/replacements/test/PEGraphDecoderTest.java
@@ -231,7 +231,7 @@ public class PEGraphDecoderTest extends GraalCompilerTest {
             graphBuilderConfig = editGraphBuilderConfiguration(graphBuilderConfig);
             registerPlugins(graphBuilderConfig.getPlugins().getInvocationPlugins());
             targetGraph = new StructuredGraph.Builder(debug.getOptions(), debug, AllowAssumptions.YES).method(testMethod).build();
-            CachingPEGraphDecoder decoder = new CachingPEGraphDecoder(getTarget().arch, targetGraph, getProviders(), graphBuilderConfig, OptimisticOptimizations.NONE,
+            CachingPEGraphDecoder decoder = new CachingPEGraphDecoder(getTarget().arch, targetGraph, getProviders(), getProviders(), graphBuilderConfig, OptimisticOptimizations.NONE,
                             null, null, new InlineInvokePlugin[]{new InlineAll()}, null, null, null, null, null, graphCache, () -> null, false, false, true);
 
             decoder.decode(testMethod);

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/TruffleCachingConstantFieldProvider.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/TruffleCachingConstantFieldProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.truffle.compiler;
+
+import com.oracle.truffle.compiler.ConstantFieldInfo;
+
+import org.graalvm.compiler.core.common.spi.ConstantFieldProvider;
+import org.graalvm.compiler.replacements.CachingPEGraphDecoder;
+import jdk.vm.ci.meta.ResolvedJavaField;
+
+/**
+ * Constant field provider used for parsing into the graph cache on HotSpot in
+ * {@link CachingPEGraphDecoder}.
+ */
+final class TruffleCachingConstantFieldProvider implements ConstantFieldProvider {
+
+    private final PartialEvaluator partialEvaluator;
+    private final ConstantFieldProvider delegate;
+
+    TruffleCachingConstantFieldProvider(PartialEvaluator partialEvaluator, ConstantFieldProvider delegate) {
+        this.partialEvaluator = partialEvaluator;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public <T> T readConstantField(ResolvedJavaField field, ConstantFieldTool<T> tool) {
+        boolean isStaticField = field.isStatic();
+        if (!isStaticField && tool.getReceiver().isNull()) {
+            return null;
+        }
+        ConstantFieldInfo info = partialEvaluator.getConstantFieldInfo(field);
+        if (info != null) {
+            /*
+             * Non-null info means the field is annotated by one of the
+             * annotations @CompilationFinal, @Child or @Children. We are not folding such fields
+             * for the code cache on HotSpot. Not even static final fields. We delay this to the
+             * partial evaluation phase to ensure we are not losing the annotation information and
+             * are not reading values that are not yet stable when creating the graph for the cache.
+             * For example, a static final array annotated by '@CompilationFinal(dimensions = 1)':
+             * We cannot fold the array with 'stableDimension=1', because for the cache, the first
+             * dimension is not stable. We cannot fold it with 'stableDimension=0' either, because
+             * we would lose the information about the first dimension being stable for the partial
+             * evaluation phase.
+             **/
+            return null;
+        } else {
+            // otherwise do regular constant folding.
+            return delegate.readConstantField(field, tool);
+        }
+    }
+
+    @Override
+    public boolean maybeFinal(ResolvedJavaField field) {
+        return delegate.maybeFinal(field);
+    }
+
+}

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/TruffleConstantFieldProvider.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/TruffleConstantFieldProvider.java
@@ -32,6 +32,11 @@ import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaField;
 
+/**
+ * Constant field provider used for Truffle partial evaluation.
+ *
+ * @see TruffleCachingConstantFieldProvider
+ */
 final class TruffleConstantFieldProvider implements ConstantFieldProvider {
 
     private final PartialEvaluator partialEvaluator;


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11488

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**

- Merge issue: CachingPEGraphDecoder has a different parameter list on mainline vs. graalvm-community-jdk21u
- Resolution: adopt the mainline change by adding graphCacheProviders and decodingProviders; do not refactor or re-align surrounding code
```
<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/replacements/CachingPEGraphDecoder.java
    public CachingPEGraphDecoder(Architecture architecture, StructuredGraph graph, Providers providers, GraphBuilderConfiguration graphBuilderConfig, OptimisticOptimizations optimisticOpts,
                    LoopExplosionPlugin loopExplosionPlugin, InvocationPlugins invocationPlugins, InlineInvokePlugin[] inlineInvokePlugins,
=======
    public CachingPEGraphDecoder(Architecture architecture,
                    StructuredGraph graph,
                    Providers graphCacheProviders,
                    Providers decodingProviders,
                    GraphBuilderConfiguration graphBuilderConfig,
                    LoopExplosionPlugin loopExplosionPlugin,
                    InvocationPlugins invocationPlugins,
                    InlineInvokePlugin[] inlineInvokePlugins,
>>>>>>> 72dd8ab530f (Don't use TruffleConstantFieldProvider for caching in CachingPEGraphDecoder. Implement a dedicated caching graph cache providers when parsing IR for the graph cache that never folds compilation final or child fields.):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/CachingPEGraphDecoder.java

<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/replacements/test/PEGraphDecoderTest.java
            CachingPEGraphDecoder decoder = new CachingPEGraphDecoder(getTarget().arch, targetGraph, getProviders(), graphBuilderConfig, OptimisticOptimizations.NONE,
                            null, null, new InlineInvokePlugin[]{new InlineAll()}, null, null, null, null, null, graphCache, () -> null, false, false, true);
=======
            GraphBuilderPhase.Instance instance = new TestGraphBuilderPhase.Instance(getProviders(), graphBuilderConfig, OptimisticOptimizations.NONE, null);
            CachingPEGraphDecoder decoder = new CachingPEGraphDecoder(getTarget().arch, targetGraph, getProviders(), getProviders(), graphBuilderConfig,
                            null, null, new InlineInvokePlugin[]{new InlineAll()}, null, null, null, null, null, graphCache, () -> null, instance, false, false, true);
>>>>>>> 72dd8ab530f (Don't use TruffleConstantFieldProvider for caching in CachingPEGraphDecoder. Implement a dedicated caching graph cache providers when parsing IR for the graph cache that never folds compilation final or child fields.):compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/replacements/test/PEGraphDecoderTest.java

<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/PartialEvaluator.java
        return new CachingPEGraphDecoder(config.architecture(), context.graph, compilationUnitProviders, newConfig, TruffleCompilerImpl.Optimizations,
                        loopExplosionPlugin, decodingPlugins, inlineInvokePlugins, parameterPlugin, nodePluginList, types.OptimizedCallTarget_callInlined,
                        sourceLanguagePositionProvider, postParsingPhase, graphCache, createCachedGraphScope, allowAssumptionsDuringParsing, false, true);
=======
        return new CachingPEGraphDecoder(config.architecture(), context.graph, graphCacheProviders, decoderProviders, newConfig,
                        loopExplosionPlugin, decodingPlugins, inlineInvokePlugins, parameterPlugin, nodePluginList, types.OptimizedCallTarget_callInlined,
                        sourceLanguagePositionProvider, postParsingPhase, graphCache, createCachedGraphScope,
                        createGraphBuilderPhaseInstance(graphCacheProviders, newConfig, TruffleCompilerImpl.Optimizations),
                        allowAssumptionsDuringParsing, false, true);
>>>>>>> 72dd8ab530f (Don't use TruffleConstantFieldProvider for caching in CachingPEGraphDecoder. Implement a dedicated caching graph cache providers when parsing IR for the graph cache that never folds compilation final or child fields.):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/truffle/PartialEvaluator.java
```

Newly introduced TruffleConstantFieldProvider class:
- move: jdk.graal.compiler/src/jdk/graal/compiler/truffle -> jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler
- Dropped isTrustedFinal override - method not present in 23.1 ConstantFieldProvider:
```
graal/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/TruffleCachingConstantFieldProvider.java:80: error: method does not override or implement a method from a supertype
    @Override
    ^
graal/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/TruffleCachingConstantFieldProvider.java:82: error: cannot find symbol
        return delegate.isTrustedFinal(tool, field);
                       ^
  symbol:   method isTrustedFinal(CanonicalizerTool,ResolvedJavaField)
  location: variable delegate of type ConstantFieldProvider
```

**Not backported: DeoptLoopDetectionTest.java** This file was introduced on mainline with [GR-43908] (oracle/graal#11277, Automatically detect deopt recompile cycles). It contains several tests that depend on that feature and fail without it. In particular, the new test testStaticAssumptionNoDeopt fails if GR-43908 is absent, producing: _"org.junit.ComparisonFailure: expected:<[No deopt loop detected after 1024 executions]> but was:<[Maximum compilation count 100 reached.]>"_

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/184