### PR TITLE
[Backport] [Oracle GraalVM] [GR-68032] Backport to 23.1: Improve -XX:FlightRecorderLogging error message for unknown tag set.

### DIFF
--- a/docs/reference-manual/native-image/JFR.md
+++ b/docs/reference-manual/native-image/JFR.md
@@ -89,7 +89,7 @@ You can configure the logging for the JFR system with a separate flag `-XX:Fligh
 The usage is: `-XX:FlightRecorderLogging=[tag1[+tag2...][*][=level][,...]]`. 
 For example:
 ```shell
--XX:FlightRecorderLogging=jfr,system=debug
+-XX:FlightRecorderLogging=jfr+system=debug
 -XX:FlightRecorderLogging=all=trace
 -XX:FlightRecorderLogging=jfr*=error
 ```

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/logging/JfrLogConfiguration.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/logging/JfrLogConfiguration.java
@@ -27,6 +27,7 @@ package com.oracle.svm.core.jfr.logging;
 
 import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -91,8 +92,27 @@ final class JfrLogConfiguration {
     private static void verifySelections(JfrLogSelection[] selections) {
         for (JfrLogSelection selection : selections) {
             if (!selection.matchesATagSet) {
+                // prepare suggestions
+                StringBuilder logTagSuggestions = new StringBuilder();
+                for (Set<JfrLogTag> valid : JfrLogConfiguration.LOG_TAG_SETS.values()) {
+                    if (valid.containsAll(selection.tags)) {
+                        boolean first = true;
+                        for (JfrLogTag jfrLogTag : valid) {
+                            if (!first) {
+                                logTagSuggestions.append("+");
+                            }
+                            logTagSuggestions.append(jfrLogTag.toString().toLowerCase(Locale.ROOT));
+                            first = false;
+                        }
+                        if (!logTagSuggestions.isEmpty()) {
+                            logTagSuggestions.append(" ");
+                        }
+                    }
+                }
+
                 throw new IllegalArgumentException("No tag set matches tag combination " +
-                                selection.tags.toString().toLowerCase() + (selection.wildcard ? "*" : "") + " for FlightRecorderLogging");
+                                selection.tags.toString().toLowerCase(Locale.ROOT) + (selection.wildcard ? "*" : "") + " for FlightRecorderLogging" +
+                                (logTagSuggestions.isEmpty() ? "" : ". Did you mean any of the following? " + logTagSuggestions));
             }
         }
     }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11733

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**

- Minor conflict: case-folding call differs, toLowerCase() vs toLowerCase(Locale.ROOT)
- Resolution: accept the upstream variant: use toLowerCase(Locale.ROOT)
```
<<<<<<< HEAD
  selection.tags.toString().toLowerCase() + (selection.wildcard ? "*" : "") + " for FlightRecorderLogging");
=======
  selection.tags.toString().toLowerCase(Locale.ROOT) + (selection.wildcard ? "*" : "") + " for FlightRecorderLogging" +
    (logTagSuggestions.isEmpty() ? "" : ". Did you mean any of the following? " + logTagSuggestions));
>>>>>>> d34fd1f0578 (svm: improve -XX:FlightRecorderLogging error message for unknown tag set)
```

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/187
