### PR TITLE
[Backport] [Oracle GraalVM] [GR-67962] Backport to 23.1: SubstrateDiagnostics and OutOfMemoryError bugfixes.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -405,7 +405,7 @@ public class SubstrateOptions {
     }
 
     /* Same option name and specification as the Java HotSpot VM. */
-    @Option(help = "Maximum total size of NIO direct-buffer allocations")//
+    @Option(help = "Maximum total size of NIO direct-buffer allocations", type = OptionType.Expert)//
     public static final RuntimeOptionKey<Long> MaxDirectMemorySize = new RuntimeOptionKey<>(0L);
 
     @Option(help = "Verify naming conventions during image construction.")//

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/OutOfMemoryUtil.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/OutOfMemoryUtil.java
@@ -33,6 +33,7 @@ import com.oracle.svm.core.heap.dump.HeapDumping;
 import com.oracle.svm.core.jdk.JDKUtils;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.stack.StackOverflowCheck;
+import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.util.VMError;
 
 /**
@@ -62,6 +63,11 @@ public class OutOfMemoryUtil {
 
     @Uninterruptible(reason = "Not uninterruptible but it doesn't matter for the callers.", calleeMustBe = false)
     private static void reportOutOfMemoryError0(OutOfMemoryError error) {
+        if (VMOperation.isGCInProgress()) {
+            /* If a GC is in progress, then we can't execute the more complex logic below. */
+            return;
+        }
+
         if (VMInspectionOptions.hasHeapDumpSupport() && SubstrateOptions.HeapDumpOnOutOfMemoryError.getValue()) {
             HeapDumping.singleton().dumpHeapOnOutOfMemoryError();
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/ChunkBasedCommittedMemoryProvider.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/ChunkBasedCommittedMemoryProvider.java
@@ -33,12 +33,13 @@ import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.config.ConfigurationValues;
+import com.oracle.svm.core.heap.OutOfMemoryUtil;
 import com.oracle.svm.core.heap.RestrictHeapAccess;
 
 public abstract class ChunkBasedCommittedMemoryProvider extends AbstractCommittedMemoryProvider {
-    private static final OutOfMemoryError ALIGNED_OUT_OF_MEMORY_ERROR = new OutOfMemoryError("Could not allocate an aligned heap chunk. " +
+    protected static final OutOfMemoryError ALIGNED_CHUNK_COMMIT_FAILED = new OutOfMemoryError("Could not commit an aligned heap chunk. " +
                     "Either the OS/container is out of memory or another system-level resource limit was reached (such as the number of memory mappings).");
-    private static final OutOfMemoryError UNALIGNED_OUT_OF_MEMORY_ERROR = new OutOfMemoryError("Could not allocate an unaligned heap chunk. " +
+    protected static final OutOfMemoryError UNALIGNED_CHUNK_COMMIT_FAILED = new OutOfMemoryError("Could not commit an unaligned heap chunk. " +
                     "Either the OS/container is out of memory or another system-level resource limit was reached (such as the number of memory mappings).");
 
     @Fold
@@ -50,7 +51,7 @@ public abstract class ChunkBasedCommittedMemoryProvider extends AbstractCommitte
     public Pointer allocateAlignedChunk(UnsignedWord nbytes, UnsignedWord alignment) {
         Pointer result = allocate(nbytes, alignment, false);
         if (result.isNull()) {
-            throw ALIGNED_OUT_OF_MEMORY_ERROR;
+            throw OutOfMemoryUtil.reportOutOfMemoryError(ALIGNED_CHUNK_COMMIT_FAILED);
         }
         return result;
     }
@@ -58,7 +59,7 @@ public abstract class ChunkBasedCommittedMemoryProvider extends AbstractCommitte
     public Pointer allocateUnalignedChunk(UnsignedWord nbytes) {
         Pointer result = allocate(nbytes, getAlignmentForUnalignedChunks(), false);
         if (result.isNull()) {
-            throw UNALIGNED_OUT_OF_MEMORY_ERROR;
+            throw OutOfMemoryUtil.reportOutOfMemoryError(UNALIGNED_CHUNK_COMMIT_FAILED);
         }
         return result;
     }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11688

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**

SubstrateDiagnostics.java:
- Upstream adds assert to add/addAfter in SubstrateDiagnostics - the corresponding code paths are absent in graalvm-community-jdk21u, and BuildPhaseProvider.isAnalysisStarted() method is missing
- Resolution: skipped.
```diff
        @Platforms(Platform.HOSTED_ONLY.class)
        public synchronized void add(DiagnosticThunk thunk) {
+           assert !BuildPhaseProvider.isAnalysisStarted();
            thunks.add(thunk);
            resizeInitialInvocationCount();
        }

        @Platforms(Platform.HOSTED_ONLY.class)
        public synchronized void add(int insertPos, DiagnosticThunk... extraThunks) {
+           assert !BuildPhaseProvider.isAnalysisStarted();
            for (int i = 0; i < extraThunks.length; i++) {
                thunks.add(insertPos + i, extraThunks[i]);
            }
            resizeInitialInvocationCount();
        }

        @Platforms(Platform.HOSTED_ONLY.class)
        public synchronized void addAfter(DiagnosticThunk thunk, Class<? extends DiagnosticThunk> before) {
+           assert !BuildPhaseProvider.isAnalysisStarted();
            int insertPos = indexOf(before) + 1;
            assert insertPos > 0;
            thunks.add(insertPos, thunk);
            resizeInitialInvocationCount();
        }
```

AddressRangeCommittedMemoryProvider diagnostic messages update:
- AddressRangeCommittedMemoryProvider does not exist in graalvm-community-jdk21u. It was introduced on mainline by https://github.com/oracle/graal/pull/10323
- Skipped

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/188
