### PR TITLE
[Backport] [Oracle GraalVM] [GR-68356] Backport to 23.1: Make EventBinding a context heap boundary.

### DIFF
--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/ObjectSizeCalculator.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/ObjectSizeCalculator.java
@@ -72,6 +72,7 @@ import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.impl.DefaultTruffleRuntime;
 import com.oracle.truffle.api.instrumentation.AllocationReporter;
+import com.oracle.truffle.api.instrumentation.EventBinding;
 import com.oracle.truffle.api.instrumentation.ExecutionEventListener;
 import com.oracle.truffle.api.instrumentation.TruffleInstrument;
 import com.oracle.truffle.api.io.TruffleProcessBuilder;
@@ -351,6 +352,8 @@ final class ObjectSizeCalculator {
 
                         (obj instanceof ContextLocal) ||
                         (obj instanceof ContextThreadLocal) ||
+
+                        (obj instanceof EventBinding<?>) ||
                         /*
                          * For safety, copy the asserts here in case asserts are disabled.
                          */


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11835

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/190