### PR TITLE
[Backport] [Oracle GraalVM] [GR-67898] Backport to 23.1: Avoid recursive printing of exception causes.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -711,11 +711,10 @@ public class NativeImageGeneratorRunner {
         } else {
             reportUserError(e.getMessage());
         }
-        Throwable current = e.getCause();
-        while (current != null) {
+        Throwable cause = e.getCause();
+        if (cause != null) {
             System.out.print("Caused by: ");
-            current.printStackTrace(System.out);
-            current = current.getCause();
+            cause.printStackTrace(System.out);
         }
         if (parsedHostedOptions != null && NativeImageOptions.ReportExceptionStackTraces.getValue(parsedHostedOptions)) {
             System.out.print("Internal exception: ");


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10260

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/195