### PR TITLE
[Backport] [Oracle GraalVM] [GR-67842] Backport to 23.1: Espresso standalone with G1 gets stuck if there is an argument is not recognized.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
@@ -687,11 +687,11 @@ public abstract class VMThreads {
 
         @Override
         protected void operate() {
-            IsolateThread currentThread = CurrentIsolate.getCurrentThread();
+            IsolateThread operationThread = CurrentIsolate.getCurrentThread();
             IsolateThread thread = firstThread();
             while (thread.isNonNull()) {
                 IsolateThread next = nextThread(thread);
-                if (thread.notEqual(currentThread) && !wasStartedByCurrentIsolate(thread)) {
+                if (thread.notEqual(queuingThread) && thread.notEqual(operationThread) && !wasStartedByCurrentIsolate(thread)) {
                     detachThreadInSafeContext(thread);
                     releaseThread(thread);
                 }


### PR DESCRIPTION
**Backports:**
- https://github.com/oracle/graal/pull/11719

**Conflicts:**

- VMThreads.java merge conflict: if-block body changed on mainline.
- Resolution: updated the if-block condition manually.
- For reference, mainline commit 5fc4163 (missing in the GraalVM Community JDK 21u codebase) modified the if-block content
```diff
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
@@ -702,8 +676,12 @@ public abstract class VMThreads {
             while (thread.isNonNull()) {
                 IsolateThread next = nextThread(thread);
                 if (thread.notEqual(currentThread) && !wasStartedByCurrentIsolate(thread)) {
-                    detachThreadInSafeContext(thread);
-                    releaseThread(thread);
+                    /*
+                     * The code below is similar to VMThreads.detachCurrentThread() except that it
+                     * doesn't call VMThreads.threadExit(). We assume that this is tolerable
+                     * considering the immediately following tear-down.
+                     */
+                    VMThreads.singleton().detachThread(thread, false);
                 }
                 thread = next;
             }
```
</details>

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/223
