### PR TITLE
[Backport] [Oracle GraalVM] [GR-67944] Backport to 23.1: Report more information if the heap verification finds a broken reference on the stack.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapVerifier.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapVerifier.java
@@ -36,6 +36,7 @@ import com.oracle.svm.core.MemoryWalker;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.genscavenge.AlignedHeapChunk.AlignedHeader;
+import com.oracle.svm.core.genscavenge.StackVerifier.VerifyFrameReferencesVisitor;
 import com.oracle.svm.core.genscavenge.UnalignedHeapChunk.UnalignedHeader;
 import com.oracle.svm.core.genscavenge.remset.RememberedSet;
 import com.oracle.svm.core.heap.Heap;
@@ -390,10 +391,11 @@ public final class HeapVerifier {
     }
 
     private static void printParent(Object parentObject) {
-        if (parentObject != null) {
-            Log.log().string("The object that contains the invalid reference is of type ").string(parentObject.getClass().getName()).newline();
+        if (parentObject instanceof VerifyFrameReferencesVisitor visitor) {
+            Log.log().string("The invalid reference is on the stack: sp=").zhex(visitor.getSP()).string(", ip=").zhex(visitor.getIP()).newline();
         } else {
-            Log.log().string("The invalid reference is on the stack").newline();
+            assert parentObject != null;
+            Log.log().string("The object that contains the invalid reference is of type ").string(parentObject.getClass().getName()).newline();
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/StackVerifier.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/StackVerifier.java
@@ -90,22 +90,35 @@ final class StackVerifier {
         @Override
         @RestrictHeapAccess(access = RestrictHeapAccess.Access.NO_ALLOCATION, reason = "Must not allocate while verifying the stack.")
         public boolean visitFrame(Pointer currentSP, CodePointer currentIP, CodeInfo codeInfo, DeoptimizedFrame deoptimizedFrame) {
-            verifyFrameReferencesVisitor.initialize();
+            verifyFrameReferencesVisitor.initialize(currentSP, currentIP);
             CodeInfoTable.visitObjectReferences(currentSP, currentIP, codeInfo, deoptimizedFrame, verifyFrameReferencesVisitor);
             result &= verifyFrameReferencesVisitor.result;
             return true;
         }
     }
 
-    private static class VerifyFrameReferencesVisitor implements ObjectReferenceVisitor {
+    public static class VerifyFrameReferencesVisitor implements ObjectReferenceVisitor {
+        private Pointer sp;
+        private CodePointer ip;
         private boolean result;
 
         @Platforms(Platform.HOSTED_ONLY.class)
         VerifyFrameReferencesVisitor() {
         }
 
-        public void initialize() {
+        @SuppressWarnings("hiding")
+        public void initialize(Pointer sp, CodePointer ip) {
+            this.sp = sp;
+            this.ip = ip;
             this.result = true;
+        }
+
+        public Pointer getSP() {
+            return sp;
+        }
+
+        public CodePointer getIP() {
+            return ip;
         }
 
         @Override


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/11720

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts: [1]** 

The change (currentSP, currentIP params of verifyFrameReferencesVisitor.initialize) have to be applied manually to visitFrame in current code base:
```
<<<<<<< HEAD
        public boolean visitFrame(Pointer currentSP, CodePointer currentIP, CodeInfo codeInfo, DeoptimizedFrame deoptimizedFrame) {
            verifyFrameReferencesVisitor.initialize();
            CodeInfoTable.visitObjectReferences(currentSP, currentIP, codeInfo, deoptimizedFrame, verifyFrameReferencesVisitor);
=======
        public boolean visitRegularFrame(Pointer currentSP, CodePointer currentIP, CodeInfo codeInfo) {
            verifyFrameReferencesVisitor.initialize(currentSP, currentIP);
            CodeInfoTable.visitObjectReferences(currentSP, currentIP, codeInfo, verifyFrameReferencesVisitor);
>>>>>>> 7b247bbec1d (Report more information if the heap verification finds a broken reference on the stack.)
```
==>
```diff
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/StackVer    +++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/StackVer
@@ -89,7 +89,7 @@ public void initialize() {                                                       |  @@ -90,24 +90,37 @@ final class StackVerifier {
         @Override                                                                                             @Override
         @RestrictHeapAccess(access = RestrictHeapAccess.Access.NO_ALLOCATION, reason = "Must not              @RestrictHeapAccess(access = RestrictHeapAccess.Access.NO_ALLOCATION, reason = "Must not
         public boolean visitRegularFrame(Pointer currentSP, CodePointer currentIP, CodeInfo codeI |           public boolean visitFrame(Pointer currentSP, CodePointer currentIP, CodeInfo codeInfo, De
-            verifyFrameReferencesVisitor.initialize();                                               -            verifyFrameReferencesVisitor.initialize();
+            verifyFrameReferencesVisitor.initialize(currentSP, currentIP);                           +            verifyFrameReferencesVisitor.initialize(currentSP, currentIP);
             CodeInfoTable.visitObjectReferences(currentSP, currentIP, codeInfo, verifyFrameRefere |               CodeInfoTable.visitObjectReferences(currentSP, currentIP, codeInfo, deoptimizedFrame,
             result &= verifyFrameReferencesVisitor.result;                                                        result &= verifyFrameReferencesVisitor.result;
             return true;                                                                                          return true;
```

**Conflicts: [2]**

visitObjectReferences update: 
```diff
         public void visitObjectReferences(Pointer firstObjRef, boolean compressed, int referenceSize, Object holderObject, int count) {
+            assert holderObject == null;
+
             Pointer pos = firstObjRef;
             Pointer end = firstObjRef.add(Word.unsigned(count).multiply(referenceSize));
             while (pos.belowThan(end)) {
-                visitObjectReference(pos, compressed, holderObject);
+                visitObjectReference(pos, compressed);
                 pos = pos.add(referenceSize);
             }
         }
 
-        private void visitObjectReference(Pointer objRef, boolean compressed, Object holderObject) {
-            result &= HeapVerifier.verifyReference(holderObject, objRef, compressed);
+        private void visitObjectReference(Pointer objRef, boolean compressed) {
+            result &= HeapVerifier.verifyReference(this, objRef, compressed);
         }
```
- **is not applicable**  without commit [9feb32da](https://github.com/oracle/graal/commit/9feb32da) update that introduced visitObjectReferences() on the mainline  
```diff
+++ substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GreyToBlackObjRefVisitor.java
@@ -60,31 +59,32 @@ final class GreyToBlackObjRefVisitor implements ObjectReferenceVisitor {
     }

     @Override
+    @AlwaysInline("GC performance")
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean visitObjectReference(Pointer objRef, boolean compressed, Object holderObject) {
-        return visitObjectReferenceInline(objRef, 0, compressed, holderObject);
+    public void visitObjectReferences(Pointer firstObjRef, boolean compressed, int referenceSize, Object holderObject, int count) {
+        Pointer pos = firstObjRef;
+        Pointer end = firstObjRef.add(Word.unsigned(count).multiply(referenceSize));
+        while (pos.belowThan(end)) {
+            visitObjectReference(pos, compressed, holderObject);
+            pos = pos.add(referenceSize);
+        }
     }
```
resoltution: skipped.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/222
