### PR TITLE
Backport reachability metadata changes

### DIFF
--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ParserConfigurationAdapter.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ParserConfigurationAdapter.java
@@ -156,6 +156,12 @@ public class ParserConfigurationAdapter implements ReflectionConfigurationParser
     }
 
     @Override
+    public void registerAsSerializable(ConfigurationCondition condition, ConfigurationType type) {
+        throw new IllegalArgumentException("The serializable field is not supported when reading reachability-metadata.json files on this version of GraalVM. " +
+                        "Please upgrade to the latest version.");
+    }
+
+    @Override
     public String getTypeName(ConfigurationType type) {
         return type.getQualifiedJavaName();
     }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ParserConfigurationAdapter.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ParserConfigurationAdapter.java
@@ -61,18 +61,18 @@ public class ParserConfigurationAdapter implements ReflectionConfigurationParser
     }
 
     @Override
-    public void registerField(ConfigurationCondition condition, ConfigurationType type, String fieldName, boolean finalButWritable) {
+    public void registerField(ConfigurationCondition condition, ConfigurationType type, String fieldName, boolean finalButWritable, boolean jniAccessible) {
         type.addField(fieldName, ConfigurationMemberDeclaration.PRESENT, finalButWritable);
     }
 
     @Override
-    public boolean registerAllMethodsWithName(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type, String methodName) {
+    public boolean registerAllMethodsWithName(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, ConfigurationType type, String methodName) {
         type.addMethodsWithName(methodName, ConfigurationMemberDeclaration.PRESENT, queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
         return true;
     }
 
     @Override
-    public boolean registerAllConstructors(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
+    public boolean registerAllConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, ConfigurationType type) {
         type.addMethodsWithName(ConfigurationMethod.CONSTRUCTOR_NAME, ConfigurationMemberDeclaration.PRESENT,
                         queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
         return true;
@@ -84,13 +84,13 @@ public class ParserConfigurationAdapter implements ReflectionConfigurationParser
     }
 
     @Override
-    public void registerMethod(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type, String methodName, List<ConfigurationType> methodParameterTypes) {
+    public void registerMethod(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type, String methodName, List<ConfigurationType> methodParameterTypes, boolean jniAccessible) {
         type.addMethod(methodName, ConfigurationMethod.toInternalParamsSignature(methodParameterTypes), ConfigurationMemberDeclaration.PRESENT,
                         queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
-    public void registerConstructor(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type, List<ConfigurationType> methodParameterTypes) {
+    public void registerConstructor(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type, List<ConfigurationType> methodParameterTypes, boolean jniAccessible) {
         type.addMethod(ConfigurationMethod.CONSTRUCTOR_NAME, ConfigurationMethod.toInternalParamsSignature(methodParameterTypes), ConfigurationMemberDeclaration.PRESENT,
                         queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
@@ -126,38 +126,44 @@ public class ParserConfigurationAdapter implements ReflectionConfigurationParser
     }
 
     @Override
-    public void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
+    public void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, ConfigurationType type) {
         type.setAllPublicFields();
     }
 
     @Override
-    public void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
+    public void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, ConfigurationType type) {
         type.setAllDeclaredFields();
     }
 
     @Override
-    public void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
+    public void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, ConfigurationType type) {
         type.setAllPublicMethods(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
-    public void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
+    public void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, ConfigurationType type) {
         type.setAllDeclaredMethods(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
-    public void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
+    public void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, ConfigurationType type) {
         type.setAllPublicConstructors(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
-    public void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, ConfigurationType type) {
+    public void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, ConfigurationType type) {
         type.setAllDeclaredConstructors(queriedOnly ? ConfigurationMemberAccessibility.QUERIED : ConfigurationMemberAccessibility.ACCESSED);
     }
 
     @Override
     public void registerAsSerializable(ConfigurationCondition condition, ConfigurationType type) {
         throw new IllegalArgumentException("The serializable field is not supported when reading reachability-metadata.json files on this version of GraalVM. " +
+                        "Please upgrade to the latest version.");
+    }
+
+    @Override
+    public void registerAsJniAccessed(ConfigurationCondition condition, ConfigurationType type) {
+        throw new IllegalArgumentException("The jniAccessible field is not supported when reading reachability-metadata.json files on this version of GraalVM. " +
                         "Please upgrade to the latest version.");
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ClassNameSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ClassNameSupport.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.configure;
+
+import jdk.vm.ci.meta.JavaKind;
+
+/**
+ * There isn't a single standard way of referring to classes by name in the Java ecosystem. In the
+ * context of Native Image reflection, there are three main ways of referring to a class:
+ *
+ * <ul>
+ * <li>The "type name": this is the result of calling {@code getTypeName()} on a {@code Class}
+ * object. This is a human-readable name and is the preferred way of specifying classes in JSON
+ * metadata files.</li>
+ * <li>The "reflection name": this is used for calls to {@link Class#forName(String)} and others
+ * using the same syntax. It is the binary name of the class except for array classes, where it is
+ * formed using the internal name of the class.</li>
+ * <li>The "JNI name": this is used for calls to {code FindClass} through JNI. This name is similar
+ * to the reflection name but uses '/' instead of '.' as package separator.</li>
+ * </ul>
+ *
+ * This class provides utility methods to be able to switch between those names and avoid confusion
+ * about which format a given string is encoded as.
+ *
+ * Here is a breakdown of the various names of different types of classes:
+ *
+ * <pre>
+ * | Type            | Type name           | Reflection name      | JNI name             |
+ * | --------------- | ------------------- | -------------------- | -------------------- |
+ * | Regular class   | package.ClassName   | package.ClassName    | package/ClassName    |
+ * | Primitive type  | type                | -                    | -                    |
+ * | Array type      | package.ClassName[] | [Lpackage.ClassName; | [Lpackage/ClassName; |
+ * | Primitive array | type[]              | [T                   | [T                   |
+ * | Inner class     | package.Outer$Inner | package.Outer$Inner  | package/Outer$Inner  |
+ * | Anonymous class | package.ClassName$1 | package.ClassName$1  | package/ClassName$1  |
+ * </pre>
+ */
+public class ClassNameSupport {
+    public static String reflectionNameToTypeName(String reflectionName) {
+        if (!isValidReflectionName(reflectionName)) {
+            return reflectionName;
+        }
+        return reflectionNameToTypeNameUnchecked(reflectionName);
+    }
+
+    public static String jniNameToTypeName(String jniName) {
+        if (!isValidJNIName(jniName)) {
+            return jniName;
+        }
+        return reflectionNameToTypeNameUnchecked(jniNameToReflectionNameUnchecked(jniName));
+    }
+
+    private static String reflectionNameToTypeNameUnchecked(String reflectionName) {
+        int arrayDimension = wrappingArrayDimension(reflectionName);
+        if (arrayDimension > 0) {
+            return arrayElementTypeToTypeName(reflectionName, arrayDimension) + "[]".repeat(arrayDimension);
+        }
+        return reflectionName;
+    }
+
+    public static String typeNameToReflectionName(String typeName) {
+        if (!isValidTypeName(typeName)) {
+            return typeName;
+        }
+        return typeNameToReflectionNameUnchecked(typeName);
+    }
+
+    public static String typeNameToJNIName(String typeName) {
+        if (!isValidTypeName(typeName)) {
+            return typeName;
+        }
+        return reflectionNameToJNINameUnchecked(typeNameToReflectionNameUnchecked(typeName));
+    }
+
+    private static String typeNameToReflectionNameUnchecked(String typeName) {
+        int arrayDimension = trailingArrayDimension(typeName);
+        if (arrayDimension > 0) {
+            return "[".repeat(arrayDimension) + typeNameToArrayElementType(typeName.substring(0, typeName.length() - arrayDimension * 2));
+        }
+        return typeName;
+    }
+
+    public static String jniNameToReflectionName(String jniName) {
+        if (!isValidJNIName(jniName)) {
+            return jniName;
+        }
+        return jniNameToReflectionNameUnchecked(jniName);
+    }
+
+    private static String jniNameToReflectionNameUnchecked(String jniName) {
+        return jniName.replace('/', '.');
+    }
+
+    public static String reflectionNameToJNIName(String reflectionName) {
+        if (!isValidReflectionName(reflectionName)) {
+            return reflectionName;
+        }
+        return reflectionNameToJNINameUnchecked(reflectionName);
+    }
+
+    private static String reflectionNameToJNINameUnchecked(String reflectionName) {
+        return reflectionName.replace('.', '/');
+    }
+
+    private static String arrayElementTypeToTypeName(String arrayElementType, int startIndex) {
+        char typeChar = arrayElementType.charAt(startIndex);
+        return switch (typeChar) {
+            case 'L' -> arrayElementType.substring(startIndex + 1, arrayElementType.length() - 1);
+            case 'B', 'C', 'D', 'F', 'I', 'J', 'S', 'Z' -> JavaKind.fromPrimitiveOrVoidTypeChar(typeChar).getJavaName();
+            default -> null;
+        };
+    }
+
+    private static String typeNameToArrayElementType(String typeName) {
+        Class<?> primitiveType = forPrimitiveName(typeName);
+        if (primitiveType != null) {
+            return String.valueOf(JavaKind.fromJavaClass(primitiveType).getTypeChar());
+        }
+        return "L" + typeName + ";";
+    }
+
+    public static boolean isValidTypeName(String name) {
+        return isValidFullyQualifiedClassName(name, 0, name.length() - trailingArrayDimension(name) * 2, '.');
+    }
+
+    public static boolean isValidReflectionName(String name) {
+        return isValidWrappingArraySyntaxName(name, '.');
+    }
+
+    public static boolean isValidJNIName(String name) {
+        return isValidWrappingArraySyntaxName(name, '/');
+    }
+
+    private static boolean isValidWrappingArraySyntaxName(String name, char packageSeparator) {
+        int arrayDimension = wrappingArrayDimension(name);
+        if (arrayDimension > 0) {
+            return isValidWrappingArrayElementType(name, arrayDimension, packageSeparator);
+        }
+        return isValidFullyQualifiedClassName(name, 0, name.length(), packageSeparator);
+    }
+
+    private static boolean isValidWrappingArrayElementType(String name, int startIndex, char packageSeparator) {
+        if (startIndex == name.length()) {
+            return false;
+        }
+        return switch (name.charAt(startIndex)) {
+            case 'L' ->
+                name.charAt(name.length() - 1) == ';' && isValidFullyQualifiedClassName(name, startIndex + 1, name.length() - 1, packageSeparator);
+            case 'B', 'C', 'D', 'F', 'I', 'J', 'S', 'Z' -> startIndex == name.length() - 1;
+            default -> false;
+        };
+    }
+
+    private static boolean isValidFullyQualifiedClassName(String name, int startIndex, int endIndex, char packageSeparator) {
+        int lastPackageSeparatorIndex = -1;
+        for (int i = startIndex; i < endIndex; ++i) {
+            char current = name.charAt(i);
+            if (current == packageSeparator) {
+                if (lastPackageSeparatorIndex == i - 1) {
+                    return false;
+                }
+                lastPackageSeparatorIndex = i;
+            } else if (!Character.isJavaIdentifierPart(current)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int wrappingArrayDimension(String name) {
+        int arrayDimension = 0;
+        while (arrayDimension < name.length() && name.charAt(arrayDimension) == '[') {
+            arrayDimension++;
+        }
+        return arrayDimension;
+    }
+
+    private static int trailingArrayDimension(String name) {
+        int arrayDimension = 0;
+        while (endsWithTrailingArraySyntax(name, name.length() - arrayDimension * 2)) {
+            arrayDimension++;
+        }
+        return arrayDimension;
+    }
+
+    private static boolean endsWithTrailingArraySyntax(String string, int endIndex) {
+        return endIndex >= "[]".length() && string.charAt(endIndex - 2) == '[' && string.charAt(endIndex - 1) == ']';
+    }
+
+    // Copied from java.lang.Class from JDK 22
+    public static Class<?> forPrimitiveName(String primitiveName) {
+        return switch (primitiveName) {
+            // Integral types
+            case "int" -> int.class;
+            case "long" -> long.class;
+            case "short" -> short.class;
+            case "char" -> char.class;
+            case "byte" -> byte.class;
+
+            // Floating-point types
+            case "float" -> float.class;
+            case "double" -> double.class;
+
+            // Other types
+            case "boolean" -> boolean.class;
+            case "void" -> void.class;
+
+            default -> null;
+        };
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationParser.java
@@ -75,6 +75,7 @@ public abstract class ConfigurationParser {
     public static final String GLOBS_KEY = "globs";
     public static final String MODULE_KEY = "module";
     public static final String GLOB_KEY = "glob";
+    public static final String BUNDLE_KEY = "bundle";
     private final Map<String, Set<String>> seenUnknownAttributesByType = new HashMap<>();
     private final boolean strictSchema;
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParser.java
@@ -31,10 +31,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.graalvm.collections.EconomicMap;
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.impl.ConfigurationCondition;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 import org.graalvm.util.json.JSONParserException;
 
 import com.oracle.svm.core.TypeResult;
+import com.oracle.svm.core.reflect.serialize.SerializationRegistry;
 import com.oracle.svm.util.LogUtils;
 
 /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParser.java
@@ -31,13 +31,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.graalvm.collections.EconomicMap;
-import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.impl.ConfigurationCondition;
-import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 import org.graalvm.util.json.JSONParserException;
 
 import com.oracle.svm.core.TypeResult;
-import com.oracle.svm.core.reflect.serialize.SerializationRegistry;
 import com.oracle.svm.util.LogUtils;
 
 /**
@@ -47,13 +44,15 @@ import com.oracle.svm.util.LogUtils;
 public abstract class ReflectionConfigurationParser<T> extends ConfigurationParser {
     private static final String CONSTRUCTOR_NAME = "<init>";
 
+    protected final String combinedFileKey;
     protected final ConfigurationConditionResolver conditionResolver;
     protected final ReflectionConfigurationParserDelegate<T> delegate;
     private final boolean printMissingElements;
 
-    public ReflectionConfigurationParser(ConfigurationConditionResolver conditionResolver, ReflectionConfigurationParserDelegate<T> delegate, boolean strictConfiguration,
+    public ReflectionConfigurationParser(String combinedFileKey, ConfigurationConditionResolver conditionResolver, ReflectionConfigurationParserDelegate<T> delegate, boolean strictConfiguration,
                     boolean printMissingElements) {
         super(strictConfiguration);
+        this.combinedFileKey = combinedFileKey;
         this.conditionResolver = conditionResolver;
         this.printMissingElements = printMissingElements;
         this.delegate = delegate;
@@ -64,7 +63,7 @@ public abstract class ReflectionConfigurationParser<T> extends ConfigurationPars
         if (strictMetadata) {
             return new ReflectionMetadataParser<>(combinedFileKey, ConfigurationConditionResolver.identityResolver(), delegate, strictConfiguration, printMissingElements);
         } else {
-            return new LegacyReflectionConfigurationParser<>(ConfigurationConditionResolver.identityResolver(), delegate, strictConfiguration, printMissingElements, false);
+            return new LegacyReflectionConfigurationParser<>(combinedFileKey, ConfigurationConditionResolver.identityResolver(), delegate, strictConfiguration, printMissingElements, false);
         }
     }
 
@@ -76,29 +75,31 @@ public abstract class ReflectionConfigurationParser<T> extends ConfigurationPars
 
     protected abstract void parseClass(EconomicMap<String, Object> data);
 
-    protected void registerIfNotDefault(EconomicMap<String, Object> data, boolean defaultValue, T clazz, String propertyName, Runnable register) {
+    protected boolean registerIfNotDefault(EconomicMap<String, Object> data, boolean defaultValue, T clazz, String propertyName, Runnable register) {
         if (data.containsKey(propertyName) ? asBoolean(data.get(propertyName), propertyName) : defaultValue) {
             try {
                 register.run();
+                return true;
             } catch (LinkageError e) {
                 handleMissingElement("Could not register " + delegate.getTypeName(clazz) + ": " + propertyName + " for reflection.", e);
             }
         }
+        return false;
     }
 
-    protected void parseFields(ConfigurationCondition condition, List<Object> fields, T clazz) {
+    protected void parseFields(ConfigurationCondition condition, List<Object> fields, T clazz, boolean jniAccessible) {
         for (Object field : fields) {
-            parseField(condition, asMap(field, "Elements of 'fields' array must be field descriptor objects"), clazz);
+            parseField(condition, asMap(field, "Elements of 'fields' array must be field descriptor objects"), clazz, jniAccessible);
         }
     }
 
-    private void parseField(ConfigurationCondition condition, EconomicMap<String, Object> data, T clazz) {
+    private void parseField(ConfigurationCondition condition, EconomicMap<String, Object> data, T clazz, boolean jniAccessible) {
         checkAttributes(data, "reflection field descriptor object", Collections.singleton("name"), Arrays.asList("allowWrite", "allowUnsafeAccess"));
         String fieldName = asString(data.get("name"), "name");
         boolean allowWrite = data.containsKey("allowWrite") && asBoolean(data.get("allowWrite"), "allowWrite");
 
         try {
-            delegate.registerField(condition, clazz, fieldName, allowWrite);
+            delegate.registerField(condition, clazz, fieldName, allowWrite, jniAccessible);
         } catch (NoSuchFieldException e) {
             handleMissingElement("Field " + formatField(clazz, fieldName) + " not found.");
         } catch (LinkageError e) {
@@ -106,13 +107,13 @@ public abstract class ReflectionConfigurationParser<T> extends ConfigurationPars
         }
     }
 
-    protected void parseMethods(ConfigurationCondition condition, boolean queriedOnly, List<Object> methods, T clazz) {
+    protected void parseMethods(ConfigurationCondition condition, boolean queriedOnly, List<Object> methods, T clazz, boolean jniAccessible) {
         for (Object method : methods) {
-            parseMethod(condition, queriedOnly, asMap(method, "Elements of 'methods' array must be method descriptor objects"), clazz);
+            parseMethod(condition, queriedOnly, asMap(method, "Elements of 'methods' array must be method descriptor objects"), clazz, jniAccessible);
         }
     }
 
-    private void parseMethod(ConfigurationCondition condition, boolean queriedOnly, EconomicMap<String, Object> data, T clazz) {
+    private void parseMethod(ConfigurationCondition condition, boolean queriedOnly, EconomicMap<String, Object> data, T clazz, boolean jniAccessible) {
         checkAttributes(data, "reflection method descriptor object", Collections.singleton("name"), Collections.singleton("parameterTypes"));
         String methodName = asString(data.get("name"), "name");
         List<T> methodParameterTypes = null;
@@ -128,9 +129,9 @@ public abstract class ReflectionConfigurationParser<T> extends ConfigurationPars
         if (methodParameterTypes != null) {
             try {
                 if (isConstructor) {
-                    delegate.registerConstructor(condition, queriedOnly, clazz, methodParameterTypes);
+                    delegate.registerConstructor(condition, queriedOnly, clazz, methodParameterTypes, jniAccessible);
                 } else {
-                    delegate.registerMethod(condition, queriedOnly, clazz, methodName, methodParameterTypes);
+                    delegate.registerMethod(condition, queriedOnly, clazz, methodName, methodParameterTypes, jniAccessible);
                 }
             } catch (NoSuchMethodException e) {
                 handleMissingElement("Method " + formatMethod(clazz, methodName, methodParameterTypes) + " not found.");
@@ -141,9 +142,9 @@ public abstract class ReflectionConfigurationParser<T> extends ConfigurationPars
             try {
                 boolean found;
                 if (isConstructor) {
-                    found = delegate.registerAllConstructors(condition, queriedOnly, clazz);
+                    found = delegate.registerAllConstructors(condition, queriedOnly, jniAccessible, clazz);
                 } else {
-                    found = delegate.registerAllMethodsWithName(condition, queriedOnly, clazz, methodName);
+                    found = delegate.registerAllMethodsWithName(condition, queriedOnly, jniAccessible, clazz, methodName);
                 }
                 if (!found) {
                     throw new JSONParserException("Method " + formatMethod(clazz, methodName) + " not found");

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParserDelegate.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParserDelegate.java
@@ -48,31 +48,33 @@ public interface ReflectionConfigurationParserDelegate<T> {
 
     void registerSigners(ConfigurationCondition condition, T type);
 
-    void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, T type);
+    void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, T type);
 
-    void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, T type);
+    void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, T type);
 
-    void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, T type);
+    void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, T type);
 
-    void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, T type);
+    void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, T type);
 
-    void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, T type);
+    void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, T type);
 
-    void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, T type);
+    void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, T type);
 
-    void registerField(ConfigurationCondition condition, T type, String fieldName, boolean allowWrite) throws NoSuchFieldException;
+    void registerField(ConfigurationCondition condition, T type, String fieldName, boolean allowWrite, boolean jniAccessible) throws NoSuchFieldException;
 
-    boolean registerAllMethodsWithName(ConfigurationCondition condition, boolean queriedOnly, T type, String methodName);
+    boolean registerAllMethodsWithName(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, T type, String methodName);
 
-    void registerMethod(ConfigurationCondition condition, boolean queriedOnly, T type, String methodName, List<T> methodParameterTypes) throws NoSuchMethodException;
+    void registerMethod(ConfigurationCondition condition, boolean queriedOnly, T type, String methodName, List<T> methodParameterTypes, boolean jniAccessible) throws NoSuchMethodException;
 
-    void registerConstructor(ConfigurationCondition condition, boolean queriedOnly, T type, List<T> methodParameterTypes) throws NoSuchMethodException;
+    void registerConstructor(ConfigurationCondition condition, boolean queriedOnly, T type, List<T> methodParameterTypes, boolean jniAccessible) throws NoSuchMethodException;
 
-    boolean registerAllConstructors(ConfigurationCondition condition, boolean queriedOnly, T type);
+    boolean registerAllConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, T type);
 
     void registerUnsafeAllocated(ConfigurationCondition condition, T clazz);
 
     void registerAsSerializable(ConfigurationCondition condition, T clazz);
+
+    void registerAsJniAccessed(ConfigurationCondition condition, T clazz);
 
     String getTypeName(T type);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParserDelegate.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParserDelegate.java
@@ -72,6 +72,8 @@ public interface ReflectionConfigurationParserDelegate<T> {
 
     void registerUnsafeAllocated(ConfigurationCondition condition, T clazz);
 
+    void registerAsSerializable(ConfigurationCondition condition, T clazz);
+
     String getTypeName(T type);
 
     String getSimpleName(T type);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionMetadataParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionMetadataParser.java
@@ -38,7 +38,7 @@ import com.oracle.svm.core.TypeResult;
 class ReflectionMetadataParser<T> extends ReflectionConfigurationParser<T> {
     private static final List<String> OPTIONAL_REFLECT_METADATA_ATTRS = Arrays.asList(CONDITIONAL_KEY,
                     "allDeclaredConstructors", "allPublicConstructors", "allDeclaredMethods", "allPublicMethods", "allDeclaredFields", "allPublicFields",
-                    "methods", "fields", "unsafeAllocated");
+                    "methods", "fields", "unsafeAllocated", "serializable");
 
     private final String combinedFileKey;
 
@@ -106,6 +106,7 @@ class ReflectionMetadataParser<T> extends ReflectionConfigurationParser<T> {
         registerIfNotDefault(data, false, clazz, "allDeclaredFields", () -> delegate.registerDeclaredFields(condition, false, clazz));
         registerIfNotDefault(data, false, clazz, "allPublicFields", () -> delegate.registerPublicFields(condition, false, clazz));
         registerIfNotDefault(data, false, clazz, "unsafeAllocated", () -> delegate.registerUnsafeAllocated(condition, clazz));
+        registerIfNotDefault(data, false, clazz, "serializable", () -> delegate.registerAsSerializable(condition, clazz));
 
         MapCursor<String, Object> cursor = data.getEntries();
         while (cursor.advance()) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionMetadataParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionMetadataParser.java
@@ -38,14 +38,11 @@ import com.oracle.svm.core.TypeResult;
 class ReflectionMetadataParser<T> extends ReflectionConfigurationParser<T> {
     private static final List<String> OPTIONAL_REFLECT_METADATA_ATTRS = Arrays.asList(CONDITIONAL_KEY,
                     "allDeclaredConstructors", "allPublicConstructors", "allDeclaredMethods", "allPublicMethods", "allDeclaredFields", "allPublicFields",
-                    "methods", "fields", "unsafeAllocated", "serializable");
-
-    private final String combinedFileKey;
+                    "methods", "fields", "unsafeAllocated", "serializable", "jniAccessible");
 
     ReflectionMetadataParser(String combinedFileKey, ConfigurationConditionResolver conditionResolver, ReflectionConfigurationParserDelegate<T> delegate, boolean strictConfiguration,
                     boolean printMissingElements) {
-        super(conditionResolver, delegate, strictConfiguration, printMissingElements);
-        this.combinedFileKey = combinedFileKey;
+        super(combinedFileKey, conditionResolver, delegate, strictConfiguration, printMissingElements);
     }
 
     @Override
@@ -86,27 +83,37 @@ class ReflectionMetadataParser<T> extends ReflectionConfigurationParser<T> {
         T clazz = result.get();
         delegate.registerType(conditionResult.get(), clazz);
 
+        boolean jniParser = combinedFileKey.equals(JNI_KEY);
         delegate.registerDeclaredClasses(queryCondition, clazz);
-        delegate.registerRecordComponents(queryCondition, clazz);
-        delegate.registerPermittedSubclasses(queryCondition, clazz);
-        delegate.registerNestMembers(queryCondition, clazz);
-        delegate.registerSigners(queryCondition, clazz);
         delegate.registerPublicClasses(queryCondition, clazz);
-        delegate.registerDeclaredConstructors(queryCondition, true, clazz);
-        delegate.registerPublicConstructors(queryCondition, true, clazz);
-        delegate.registerDeclaredMethods(queryCondition, true, clazz);
-        delegate.registerPublicMethods(queryCondition, true, clazz);
-        delegate.registerDeclaredFields(queryCondition, true, clazz);
-        delegate.registerPublicFields(queryCondition, true, clazz);
+        if (!jniParser) {
+            delegate.registerRecordComponents(queryCondition, clazz);
+            delegate.registerPermittedSubclasses(queryCondition, clazz);
+            delegate.registerNestMembers(queryCondition, clazz);
+            delegate.registerSigners(queryCondition, clazz);
+        }
+        delegate.registerDeclaredConstructors(queryCondition, true, jniParser, clazz);
+        delegate.registerPublicConstructors(queryCondition, true, jniParser, clazz);
+        delegate.registerDeclaredMethods(queryCondition, true, jniParser, clazz);
+        delegate.registerPublicMethods(queryCondition, true, jniParser, clazz);
+        delegate.registerDeclaredFields(queryCondition, true, jniParser, clazz);
+        delegate.registerPublicFields(queryCondition, true, jniParser, clazz);
 
-        registerIfNotDefault(data, false, clazz, "allDeclaredConstructors", () -> delegate.registerDeclaredConstructors(condition, false, clazz));
-        registerIfNotDefault(data, false, clazz, "allPublicConstructors", () -> delegate.registerPublicConstructors(condition, false, clazz));
-        registerIfNotDefault(data, false, clazz, "allDeclaredMethods", () -> delegate.registerDeclaredMethods(condition, false, clazz));
-        registerIfNotDefault(data, false, clazz, "allPublicMethods", () -> delegate.registerPublicMethods(condition, false, clazz));
-        registerIfNotDefault(data, false, clazz, "allDeclaredFields", () -> delegate.registerDeclaredFields(condition, false, clazz));
-        registerIfNotDefault(data, false, clazz, "allPublicFields", () -> delegate.registerPublicFields(condition, false, clazz));
+        boolean typeJniAccessible;
+        if (jniParser) {
+            typeJniAccessible = true;
+        } else {
+            registerIfNotDefault(data, false, clazz, "serializable", () -> delegate.registerAsSerializable(condition, clazz));
+            typeJniAccessible = registerIfNotDefault(data, false, clazz, "jniAccessible", () -> delegate.registerAsJniAccessed(condition, clazz));
+        }
+
+        registerIfNotDefault(data, false, clazz, "allDeclaredConstructors", () -> delegate.registerDeclaredConstructors(condition, false, typeJniAccessible, clazz));
+        registerIfNotDefault(data, false, clazz, "allPublicConstructors", () -> delegate.registerPublicConstructors(condition, false, typeJniAccessible, clazz));
+        registerIfNotDefault(data, false, clazz, "allDeclaredMethods", () -> delegate.registerDeclaredMethods(condition, false, typeJniAccessible, clazz));
+        registerIfNotDefault(data, false, clazz, "allPublicMethods", () -> delegate.registerPublicMethods(condition, false, typeJniAccessible, clazz));
+        registerIfNotDefault(data, false, clazz, "allDeclaredFields", () -> delegate.registerDeclaredFields(condition, false, typeJniAccessible, clazz));
+        registerIfNotDefault(data, false, clazz, "allPublicFields", () -> delegate.registerPublicFields(condition, false, typeJniAccessible, clazz));
         registerIfNotDefault(data, false, clazz, "unsafeAllocated", () -> delegate.registerUnsafeAllocated(condition, clazz));
-        registerIfNotDefault(data, false, clazz, "serializable", () -> delegate.registerAsSerializable(condition, clazz));
 
         MapCursor<String, Object> cursor = data.getEntries();
         while (cursor.advance()) {
@@ -115,10 +122,10 @@ class ReflectionMetadataParser<T> extends ReflectionConfigurationParser<T> {
             try {
                 switch (name) {
                     case "methods":
-                        parseMethods(condition, false, asList(value, "Attribute 'methods' must be an array of method descriptors"), clazz);
+                        parseMethods(condition, false, asList(value, "Attribute 'methods' must be an array of method descriptors"), clazz, typeJniAccessible);
                         break;
                     case "fields":
-                        parseFields(condition, asList(value, "Attribute 'fields' must be an array of field descriptors"), clazz);
+                        parseFields(condition, asList(value, "Attribute 'fields' must be an array of field descriptors"), clazz, typeJniAccessible);
                         break;
                 }
             } catch (LinkageError e) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ResourceConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ResourceConfigurationParser.java
@@ -62,14 +62,15 @@ public abstract class ResourceConfigurationParser extends ConfigurationParser {
     protected void parseBundlesObject(Object bundlesObject) {
         List<Object> bundles = asList(bundlesObject, "Attribute 'bundles' must be a list of bundles");
         for (Object bundle : bundles) {
-            parseBundle(bundle);
+            parseBundle(bundle, false);
         }
     }
 
-    private void parseBundle(Object bundle) {
+    protected void parseBundle(Object bundle, boolean inResourcesSection) {
         EconomicMap<String, Object> resource = asMap(bundle, "Elements of 'bundles' list must be a bundle descriptor object");
-        checkAttributes(resource, "bundle descriptor object", Collections.singletonList("name"), Arrays.asList("locales", "classNames", "condition"));
-        String basename = asString(resource.get("name"));
+        String bundleNameAttribute = inResourcesSection ? BUNDLE_KEY : NAME_KEY;
+        checkAttributes(resource, "bundle descriptor object", Collections.singletonList(bundleNameAttribute), Arrays.asList("locales", "classNames", "condition"));
+        String basename = asString(resource.get(bundleNameAttribute));
         TypeResult<ConfigurationCondition> resolvedConfigurationCondition = conditionResolver.resolveCondition(parseCondition(resource));
         if (!resolvedConfigurationCondition.isPresent()) {
             return;
@@ -191,11 +192,11 @@ public abstract class ResourceConfigurationParser extends ConfigurationParser {
         }
     }
 
-    private interface GlobPatternConsumer<T> {
+    protected interface GlobPatternConsumer<T> {
         void accept(T a, String b, String c);
     }
 
-    private void parseGlobEntry(Object data, GlobPatternConsumer<ConfigurationCondition> resourceRegistry) {
+    protected void parseGlobEntry(Object data, GlobPatternConsumer<ConfigurationCondition> resourceRegistry) {
         EconomicMap<String, Object> globObject = asMap(data, "Elements of 'globs' list must be a glob descriptor objects");
         checkAttributes(globObject, "glob resource descriptor object", Collections.singletonList(GLOB_KEY), List.of(CONDITIONAL_KEY, MODULE_KEY));
         TypeResult<ConfigurationCondition> resolvedConfigurationCondition = conditionResolver.resolveCondition(parseCondition(globObject));

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/SerializationConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/SerializationConfigurationParser.java
@@ -61,10 +61,9 @@ public abstract class SerializationConfigurationParser extends ConfigurationPars
 
     protected abstract void parseSerializationDescriptorObject(EconomicMap<String, Object> data, boolean lambdaCapturingType);
 
-    protected void registerType(ConfigurationTypeDescriptor targetSerializationClass, ConfigurationCondition condition, Object optionalCustomCtorValue) {
-        String customTargetConstructorClass = optionalCustomCtorValue != null ? asString(optionalCustomCtorValue) : null;
+    protected void registerType(ConfigurationTypeDescriptor targetSerializationClass, ConfigurationCondition condition) {
         if (targetSerializationClass instanceof NamedConfigurationTypeDescriptor namedClass) {
-            serializationSupport.registerWithTargetConstructorClass(condition, namedClass.name(), customTargetConstructorClass);
+            serializationSupport.registerWithTargetConstructorClass(condition, namedClass.name(), null);
         } else if (targetSerializationClass instanceof ProxyConfigurationTypeDescriptor proxyClass) {
             serializationSupport.registerProxyClass(condition, proxyClass.interfaceNames());
         } else {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/SerializationMetadataParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/SerializationMetadataParser.java
@@ -32,6 +32,8 @@ import org.graalvm.collections.EconomicMap;
 import org.graalvm.nativeimage.impl.ConfigurationCondition;
 import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
+import com.oracle.svm.util.LogUtils;
+
 final class SerializationMetadataParser<C> extends SerializationConfigurationParser {
 
     SerializationMetadataParser(ConfigurationConditionResolver conditionResolver, RuntimeSerializationSupport serializationSupport, boolean strictConfiguration) {
@@ -45,6 +47,8 @@ final class SerializationMetadataParser<C> extends SerializationConfigurationPar
             parseSerializationTypes(asList(serializationJson, "The serialization property must be an array of serialization descriptor object"), false);
         }
     }
+
+    private boolean customConstructorWarningTriggered = false;
 
     @Override
     protected void parseSerializationDescriptorObject(EconomicMap<String, Object> data, boolean lambdaCapturingType) {
@@ -61,7 +65,11 @@ final class SerializationMetadataParser<C> extends SerializationConfigurationPar
             return;
         }
 
-        Object optionalCustomCtorValue = data.get(CUSTOM_TARGET_CONSTRUCTOR_CLASS_KEY);
-        registerType(targetSerializationClass.get(), condition.get(), optionalCustomCtorValue);
+        if (!customConstructorWarningTriggered && data.containsKey(CUSTOM_TARGET_CONSTRUCTOR_CLASS_KEY)) {
+            customConstructorWarningTriggered = true;
+            LogUtils.warning("\"" + CUSTOM_TARGET_CONSTRUCTOR_CLASS_KEY +
+                            "\" is deprecated in reachability-metadata.json. All serializable classes can be instantiated through any superclass constructor without the use of the flag.");
+        }
+        registerType(targetSerializationClass.get(), condition.get());
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/ClassForNameSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/ClassForNameSupport.java
@@ -99,18 +99,7 @@ public final class ClassForNameSupport {
             result = PredefinedClassesSupport.getLoadedForNameOrNull(className, classLoader);
         }
         if (result == null && !ClassNameSupport.isValidReflectionName(className)) {
-            if (result == null && ClassNameSupport.isValidJNIName(className)) {
-                var jniAlias = singleton().knownClasses.get(ClassNameSupport.jniNameToReflectionName(className));
-                if (jniAlias != null) {
-                    result = new ClassNotFoundException(className);
-                }
-            }
-            if (result == null && ClassNameSupport.isValidTypeName(className)) {
-                var typeAlias = singleton().knownClasses.get(ClassNameSupport.typeNameToReflectionName(className));
-                if (typeAlias != null) {
-                    result = new ClassNotFoundException(className);
-                }
-            }
+            result = new ClassNotFoundException(className);
         }
         // Note: for non-predefined classes, we (currently) don't need to check the provided loader
         // TODO rewrite stack traces (GR-42813)

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.graalvm.nativeimage.impl.ReflectionRegistry;
+import org.graalvm.nativeimage.impl.RuntimeJNIAccessSupport;
 import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 import org.graalvm.util.json.JSONParserException;
 
@@ -55,8 +56,8 @@ import com.oracle.svm.hosted.ImageClassLoader;
 public final class ConfigurationParserUtils {
 
     public static ReflectionConfigurationParser<Class<?>> create(String combinedFileKey, boolean strictMetadata, ReflectionRegistry registry, RuntimeSerializationSupport serializationSupport,
-                    ImageClassLoader imageClassLoader) {
-        return ReflectionConfigurationParser.create(combinedFileKey, strictMetadata, RegistryAdapter.create(registry, serializationSupport, imageClassLoader),
+                    RuntimeJNIAccessSupport jniSupport, ImageClassLoader imageClassLoader) {
+        return ReflectionConfigurationParser.create(combinedFileKey, strictMetadata, RegistryAdapter.create(registry, serializationSupport, jniSupport, imageClassLoader),
                         ConfigurationFiles.Options.StrictConfiguration.getValue(), ConfigurationFiles.Options.WarnAboutMissingReflectionOrJNIMetadataElements.getValue());
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.graalvm.nativeimage.impl.ReflectionRegistry;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 import org.graalvm.util.json.JSONParserException;
 
 import com.oracle.svm.core.configure.ConfigurationFile;
@@ -53,8 +54,9 @@ import com.oracle.svm.hosted.ImageClassLoader;
 
 public final class ConfigurationParserUtils {
 
-    public static ReflectionConfigurationParser<Class<?>> create(String combinedFileKey, boolean strictMetadata, ReflectionRegistry registry, ImageClassLoader imageClassLoader) {
-        return ReflectionConfigurationParser.create(combinedFileKey, strictMetadata, RegistryAdapter.create(registry, imageClassLoader),
+    public static ReflectionConfigurationParser<Class<?>> create(String combinedFileKey, boolean strictMetadata, ReflectionRegistry registry, RuntimeSerializationSupport serializationSupport,
+                    ImageClassLoader imageClassLoader) {
+        return ReflectionConfigurationParser.create(combinedFileKey, strictMetadata, RegistryAdapter.create(registry, serializationSupport, imageClassLoader),
                         ConfigurationFiles.Options.StrictConfiguration.getValue(), ConfigurationFiles.Options.WarnAboutMissingReflectionOrJNIMetadataElements.getValue());
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
@@ -41,6 +41,7 @@ import java.util.stream.StreamSupport;
 
 import org.graalvm.nativeimage.impl.ReflectionRegistry;
 import org.graalvm.nativeimage.impl.RuntimeJNIAccessSupport;
+import org.graalvm.nativeimage.impl.RuntimeProxyCreationSupport;
 import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 import org.graalvm.util.json.JSONParserException;
 
@@ -55,9 +56,9 @@ import com.oracle.svm.hosted.ImageClassLoader;
 
 public final class ConfigurationParserUtils {
 
-    public static ReflectionConfigurationParser<Class<?>> create(String combinedFileKey, boolean strictMetadata, ReflectionRegistry registry, RuntimeSerializationSupport serializationSupport,
-                    RuntimeJNIAccessSupport jniSupport, ImageClassLoader imageClassLoader) {
-        return ReflectionConfigurationParser.create(combinedFileKey, strictMetadata, RegistryAdapter.create(registry, serializationSupport, jniSupport, imageClassLoader),
+    public static ReflectionConfigurationParser<Class<?>> create(String combinedFileKey, boolean strictMetadata, ReflectionRegistry registry, RuntimeProxyCreationSupport proxySupport,
+                    RuntimeSerializationSupport serializationSupport, RuntimeJNIAccessSupport jniSupport, ImageClassLoader imageClassLoader) {
+        return ReflectionConfigurationParser.create(combinedFileKey, strictMetadata, RegistryAdapter.create(registry, proxySupport, serializationSupport, jniSupport, imageClassLoader),
                         ConfigurationFiles.Options.StrictConfiguration.getValue(), ConfigurationFiles.Options.WarnAboutMissingReflectionOrJNIMetadataElements.getValue());
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/JNIRegistryAdapter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/JNIRegistryAdapter.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.config;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+
+import org.graalvm.nativeimage.impl.ConfigurationCondition;
+import org.graalvm.nativeimage.impl.ReflectionRegistry;
+
+import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.hosted.ImageClassLoader;
+
+public class JNIRegistryAdapter extends RegistryAdapter {
+    public JNIRegistryAdapter(ReflectionRegistry registry, ImageClassLoader classLoader) {
+        super(registry, classLoader);
+    }
+
+    @Override
+    public void registerPublicClasses(ConfigurationCondition condition, Class<?> type) {
+        registry.register(condition, type.getClasses());
+    }
+
+    @Override
+    public void registerDeclaredClasses(ConfigurationCondition condition, Class<?> type) {
+        registry.register(condition, type.getDeclaredClasses());
+    }
+
+    @Override
+    public void registerRecordComponents(ConfigurationCondition condition, Class<?> type) {
+        VMError.shouldNotReachHere("Record components cannot be accessed through JNI registrations");
+    }
+
+    @Override
+    public void registerPermittedSubclasses(ConfigurationCondition condition, Class<?> type) {
+        VMError.shouldNotReachHere("Permitted subclasses cannot be accessed through JNI registrations");
+    }
+
+    @Override
+    public void registerNestMembers(ConfigurationCondition condition, Class<?> type) {
+        VMError.shouldNotReachHere("Nest members cannot be accessed through JNI registrations");
+    }
+
+    @Override
+    public void registerSigners(ConfigurationCondition condition, Class<?> type) {
+        VMError.shouldNotReachHere("Signers cannot be accessed through JNI registrations");
+    }
+
+    @Override
+    public void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
+        ensureJniAccessible(jniAccessible);
+        super.registerPublicFields(condition, queriedOnly, false, type);
+    }
+
+    @Override
+    public void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
+        ensureJniAccessible(jniAccessible);
+        super.registerDeclaredFields(condition, queriedOnly, false, type);
+    }
+
+    @Override
+    public void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
+        ensureJniAccessible(jniAccessible);
+        super.registerPublicMethods(condition, queriedOnly, false, type);
+    }
+
+    @Override
+    public void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
+        ensureJniAccessible(jniAccessible);
+        super.registerDeclaredMethods(condition, queriedOnly, false, type);
+    }
+
+    @Override
+    public void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
+        ensureJniAccessible(jniAccessible);
+        super.registerPublicConstructors(condition, queriedOnly, false, type);
+    }
+
+    @Override
+    public void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
+        ensureJniAccessible(jniAccessible);
+        super.registerDeclaredConstructors(condition, queriedOnly, false, type);
+    }
+
+    @Override
+    protected void registerField(ConfigurationCondition condition, boolean allowWrite, boolean jniAccessible, Field field) {
+        ensureJniAccessible(jniAccessible);
+        super.registerField(condition, allowWrite, true, field);
+    }
+
+    @Override
+    protected void registerExecutable(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Executable... executable) {
+        ensureJniAccessible(jniAccessible);
+        super.registerExecutable(condition, queriedOnly, true, executable);
+    }
+
+    @Override
+    public void registerAsSerializable(ConfigurationCondition condition, Class<?> clazz) {
+        VMError.shouldNotReachHere("serializable cannot be set on JNI registrations");
+    }
+
+    @Override
+    public void registerAsJniAccessed(ConfigurationCondition condition, Class<?> clazz) {
+        VMError.shouldNotReachHere("jniAccessible cannot be set on JNI registrations");
+    }
+
+    private static void ensureJniAccessible(boolean jniAccessible) {
+        VMError.guarantee(jniAccessible, "JNIRegistryAdapter can only be used for JNI queries");
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ReflectionRegistryAdapter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ReflectionRegistryAdapter.java
@@ -35,13 +35,16 @@ import com.oracle.svm.core.TypeResult;
 import com.oracle.svm.core.configure.ConfigurationTypeDescriptor;
 import com.oracle.svm.hosted.ImageClassLoader;
 import com.oracle.svm.hosted.reflect.ReflectionDataBuilder;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 public class ReflectionRegistryAdapter extends RegistryAdapter {
     private final RuntimeReflectionSupport reflectionSupport;
+    private final RuntimeSerializationSupport serializationSupport;
 
-    ReflectionRegistryAdapter(RuntimeReflectionSupport reflectionSupport, ImageClassLoader classLoader) {
+    ReflectionRegistryAdapter(RuntimeReflectionSupport reflectionSupport, RuntimeSerializationSupport serializationSupport, ImageClassLoader classLoader) {
         super(reflectionSupport, classLoader);
         this.reflectionSupport = reflectionSupport;
+        this.serializationSupport = serializationSupport;
     }
 
     @Override
@@ -155,5 +158,10 @@ public class ReflectionRegistryAdapter extends RegistryAdapter {
                 throw e;
             }
         }
+    }
+
+    @Override
+    public void registerAsSerializable(ConfigurationCondition condition, Class<?> clazz) {
+        serializationSupport.register(condition, clazz);
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ReflectionRegistryAdapter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ReflectionRegistryAdapter.java
@@ -26,25 +26,30 @@ package com.oracle.svm.hosted.config;
 
 import static com.oracle.svm.core.MissingRegistrationUtils.throwMissingRegistrationErrors;
 
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.util.List;
 
 import org.graalvm.nativeimage.impl.ConfigurationCondition;
+import org.graalvm.nativeimage.impl.RuntimeJNIAccessSupport;
 import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 import com.oracle.svm.core.TypeResult;
 import com.oracle.svm.core.configure.ConfigurationTypeDescriptor;
 import com.oracle.svm.hosted.ImageClassLoader;
 import com.oracle.svm.hosted.reflect.ReflectionDataBuilder;
-import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 public class ReflectionRegistryAdapter extends RegistryAdapter {
     private final RuntimeReflectionSupport reflectionSupport;
     private final RuntimeSerializationSupport serializationSupport;
+    private final RuntimeJNIAccessSupport jniSupport;
 
-    ReflectionRegistryAdapter(RuntimeReflectionSupport reflectionSupport, RuntimeSerializationSupport serializationSupport, ImageClassLoader classLoader) {
+    ReflectionRegistryAdapter(RuntimeReflectionSupport reflectionSupport, RuntimeSerializationSupport serializationSupport, RuntimeJNIAccessSupport jniSupport, ImageClassLoader classLoader) {
         super(reflectionSupport, classLoader);
         this.reflectionSupport = reflectionSupport;
         this.serializationSupport = serializationSupport;
+        this.jniSupport = jniSupport;
     }
 
     @Override
@@ -92,39 +97,63 @@ public class ReflectionRegistryAdapter extends RegistryAdapter {
     }
 
     @Override
-    public void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
-        ((ReflectionDataBuilder) reflectionSupport).registerAllFieldsQuery(condition, queriedOnly, type);
+    public void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
+        if (reflectionSupport instanceof ReflectionDataBuilder reflectionDataBuilder) {
+            reflectionDataBuilder.registerAllFieldsQuery(condition, queriedOnly, type);
+        } else if (!queriedOnly) {
+            if (jniAccessible) {
+                jniSupport.register(condition, false, type.getDeclaredFields());
+            }
+        }
     }
 
     @Override
-    public void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
-        ((ReflectionDataBuilder) reflectionSupport).registerAllDeclaredFieldsQuery(condition, queriedOnly, type);
+    public void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
+        if (reflectionSupport instanceof ReflectionDataBuilder reflectionDataBuilder) {
+            reflectionDataBuilder.registerAllDeclaredFieldsQuery(condition, queriedOnly, type);
+        } else if (!queriedOnly) {
+            if (jniAccessible) {
+                jniSupport.register(condition, false, type.getFields());
+            }
+        }
     }
 
     @Override
-    public void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         reflectionSupport.registerAllMethodsQuery(condition, queriedOnly, type);
+        if (!queriedOnly && jniAccessible) {
+            jniSupport.register(condition, false, type.getMethods());
+        }
     }
 
     @Override
-    public void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         reflectionSupport.registerAllDeclaredMethodsQuery(condition, queriedOnly, type);
+        if (!queriedOnly && jniAccessible) {
+            jniSupport.register(condition, false, type.getDeclaredMethods());
+        }
     }
 
     @Override
-    public void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         reflectionSupport.registerAllConstructorsQuery(condition, queriedOnly, type);
+        if (!queriedOnly && jniAccessible) {
+            jniSupport.register(condition, false, type.getConstructors());
+        }
     }
 
     @Override
-    public void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         reflectionSupport.registerAllDeclaredConstructorsQuery(condition, queriedOnly, type);
+        if (!queriedOnly && jniAccessible) {
+            jniSupport.register(condition, false, type.getDeclaredConstructors());
+        }
     }
 
     @Override
-    public void registerField(ConfigurationCondition condition, Class<?> type, String fieldName, boolean allowWrite) throws NoSuchFieldException {
+    public void registerField(ConfigurationCondition condition, Class<?> type, String fieldName, boolean allowWrite, boolean jniAccessible) throws NoSuchFieldException {
         try {
-            super.registerField(condition, type, fieldName, allowWrite);
+            super.registerField(condition, type, fieldName, allowWrite, jniAccessible);
         } catch (NoSuchFieldException e) {
             if (throwMissingRegistrationErrors()) {
                 reflectionSupport.registerFieldLookup(condition, type, fieldName);
@@ -135,9 +164,10 @@ public class ReflectionRegistryAdapter extends RegistryAdapter {
     }
 
     @Override
-    public void registerMethod(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, String methodName, List<Class<?>> methodParameterTypes) throws NoSuchMethodException {
+    public void registerMethod(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, String methodName, List<Class<?>> methodParameterTypes, boolean jniAccessible)
+                    throws NoSuchMethodException {
         try {
-            super.registerMethod(condition, queriedOnly, type, methodName, methodParameterTypes);
+            super.registerMethod(condition, queriedOnly, type, methodName, methodParameterTypes, jniAccessible);
         } catch (NoSuchMethodException e) {
             if (throwMissingRegistrationErrors()) {
                 reflectionSupport.registerMethodLookup(condition, type, methodName, getParameterTypes(methodParameterTypes));
@@ -148,9 +178,9 @@ public class ReflectionRegistryAdapter extends RegistryAdapter {
     }
 
     @Override
-    public void registerConstructor(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, List<Class<?>> methodParameterTypes) throws NoSuchMethodException {
+    public void registerConstructor(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, List<Class<?>> methodParameterTypes, boolean jniAccessible) throws NoSuchMethodException {
         try {
-            super.registerConstructor(condition, queriedOnly, type, methodParameterTypes);
+            super.registerConstructor(condition, queriedOnly, type, methodParameterTypes, jniAccessible);
         } catch (NoSuchMethodException e) {
             if (throwMissingRegistrationErrors()) {
                 reflectionSupport.registerConstructorLookup(condition, type, getParameterTypes(methodParameterTypes));
@@ -163,5 +193,26 @@ public class ReflectionRegistryAdapter extends RegistryAdapter {
     @Override
     public void registerAsSerializable(ConfigurationCondition condition, Class<?> clazz) {
         serializationSupport.register(condition, clazz);
+    }
+
+    @Override
+    public void registerAsJniAccessed(ConfigurationCondition condition, Class<?> clazz) {
+        jniSupport.register(condition, clazz);
+    }
+
+    @Override
+    protected void registerField(ConfigurationCondition condition, boolean allowWrite, boolean jniAccessible, Field field) {
+        super.registerField(condition, allowWrite, jniAccessible, field);
+        if (jniAccessible) {
+            jniSupport.register(condition, allowWrite, field);
+        }
+    }
+
+    @Override
+    protected void registerExecutable(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Executable... executable) {
+        super.registerExecutable(condition, queriedOnly, jniAccessible, executable);
+        if (jniAccessible) {
+            jniSupport.register(condition, queriedOnly, executable);
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/RegistryAdapter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/RegistryAdapter.java
@@ -44,14 +44,15 @@ import com.oracle.svm.core.jdk.proxy.DynamicProxyRegistry;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.ImageClassLoader;
 import com.oracle.svm.util.ClassUtil;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Class<?>> {
     private final ReflectionRegistry registry;
     private final ImageClassLoader classLoader;
 
-    public static RegistryAdapter create(ReflectionRegistry registry, ImageClassLoader classLoader) {
+    public static RegistryAdapter create(ReflectionRegistry registry, RuntimeSerializationSupport serializationSupport, ImageClassLoader classLoader) {
         if (registry instanceof RuntimeReflectionSupport) {
-            return new ReflectionRegistryAdapter((RuntimeReflectionSupport) registry, classLoader);
+            return new ReflectionRegistryAdapter((RuntimeReflectionSupport) registry, serializationSupport, classLoader);
         } else {
             return new RegistryAdapter(registry, classLoader);
         }
@@ -233,6 +234,11 @@ public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Cl
 
     private void registerExecutable(ConfigurationCondition condition, boolean queriedOnly, Executable... executable) {
         registry.register(condition, queriedOnly, executable);
+    }
+
+    @Override
+    public void registerAsSerializable(ConfigurationCondition condition, Class<?> clazz) {
+        /* Serializable has no effect on JNI registrations */
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/RegistryAdapter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/RegistryAdapter.java
@@ -35,6 +35,7 @@ import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.impl.ConfigurationCondition;
 import org.graalvm.nativeimage.impl.ReflectionRegistry;
 import org.graalvm.nativeimage.impl.RuntimeJNIAccessSupport;
+import org.graalvm.nativeimage.impl.RuntimeProxyCreationSupport;
 import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
 import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
@@ -52,9 +53,10 @@ public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Cl
     protected final ReflectionRegistry registry;
     private final ImageClassLoader classLoader;
 
-    public static RegistryAdapter create(ReflectionRegistry registry, RuntimeSerializationSupport serializationSupport, RuntimeJNIAccessSupport jniSupport, ImageClassLoader classLoader) {
+    public static RegistryAdapter create(ReflectionRegistry registry, RuntimeProxyCreationSupport proxySupport, RuntimeSerializationSupport serializationSupport, RuntimeJNIAccessSupport jniSupport,
+                    ImageClassLoader classLoader) {
         if (registry instanceof RuntimeReflectionSupport) {
-            return new ReflectionRegistryAdapter((RuntimeReflectionSupport) registry, serializationSupport, jniSupport, classLoader);
+            return new ReflectionRegistryAdapter((RuntimeReflectionSupport) registry, proxySupport, serializationSupport, jniSupport, classLoader);
         } else if (registry instanceof RuntimeJNIAccessSupport) {
             return new JNIRegistryAdapter(registry, classLoader);
         } else {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/RegistryAdapter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/RegistryAdapter.java
@@ -25,6 +25,7 @@
 package com.oracle.svm.hosted.config;
 
 import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -33,7 +34,9 @@ import java.util.List;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.impl.ConfigurationCondition;
 import org.graalvm.nativeimage.impl.ReflectionRegistry;
+import org.graalvm.nativeimage.impl.RuntimeJNIAccessSupport;
 import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 import com.oracle.svm.core.TypeResult;
 import com.oracle.svm.core.configure.ConfigurationTypeDescriptor;
@@ -44,15 +47,16 @@ import com.oracle.svm.core.jdk.proxy.DynamicProxyRegistry;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.ImageClassLoader;
 import com.oracle.svm.util.ClassUtil;
-import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Class<?>> {
-    private final ReflectionRegistry registry;
+    protected final ReflectionRegistry registry;
     private final ImageClassLoader classLoader;
 
-    public static RegistryAdapter create(ReflectionRegistry registry, RuntimeSerializationSupport serializationSupport, ImageClassLoader classLoader) {
+    public static RegistryAdapter create(ReflectionRegistry registry, RuntimeSerializationSupport serializationSupport, RuntimeJNIAccessSupport jniSupport, ImageClassLoader classLoader) {
         if (registry instanceof RuntimeReflectionSupport) {
-            return new ReflectionRegistryAdapter((RuntimeReflectionSupport) registry, serializationSupport, classLoader);
+            return new ReflectionRegistryAdapter((RuntimeReflectionSupport) registry, serializationSupport, jniSupport, classLoader);
+        } else if (registry instanceof RuntimeJNIAccessSupport) {
+            return new JNIRegistryAdapter(registry, classLoader);
         } else {
             return new RegistryAdapter(registry, classLoader);
         }
@@ -108,12 +112,10 @@ public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Cl
 
     @Override
     public void registerPublicClasses(ConfigurationCondition condition, Class<?> type) {
-        registry.register(condition, type.getClasses());
     }
 
     @Override
     public void registerDeclaredClasses(ConfigurationCondition condition, Class<?> type) {
-        registry.register(condition, type.getDeclaredClasses());
     }
 
     @Override
@@ -133,47 +135,52 @@ public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Cl
     }
 
     @Override
-    public void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerPublicFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         registry.register(condition, false, type.getFields());
     }
 
     @Override
-    public void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerDeclaredFields(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         registry.register(condition, false, type.getDeclaredFields());
     }
 
     @Override
-    public void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerPublicMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         registry.register(condition, queriedOnly, type.getMethods());
     }
 
     @Override
-    public void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerDeclaredMethods(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         registry.register(condition, queriedOnly, type.getDeclaredMethods());
     }
 
     @Override
-    public void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerPublicConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         registry.register(condition, queriedOnly, type.getConstructors());
     }
 
     @Override
-    public void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public void registerDeclaredConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         registry.register(condition, queriedOnly, type.getDeclaredConstructors());
     }
 
     @Override
-    public void registerField(ConfigurationCondition condition, Class<?> type, String fieldName, boolean allowWrite) throws NoSuchFieldException {
-        registry.register(condition, allowWrite, type.getDeclaredField(fieldName));
+    public void registerField(ConfigurationCondition condition, Class<?> type, String fieldName, boolean allowWrite, boolean jniAccessible) throws NoSuchFieldException {
+        registerField(condition, allowWrite, jniAccessible, type.getDeclaredField(fieldName));
+    }
+
+    @SuppressWarnings("unused")
+    protected void registerField(ConfigurationCondition condition, boolean allowWrite, boolean jniAccessible, Field field) {
+        registry.register(condition, allowWrite, field);
     }
 
     @Override
-    public boolean registerAllMethodsWithName(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, String methodName) {
+    public boolean registerAllMethodsWithName(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type, String methodName) {
         boolean found = false;
         Executable[] methods = type.getDeclaredMethods();
         for (Executable method : methods) {
             if (method.getName().equals(methodName)) {
-                registerExecutable(condition, queriedOnly, method);
+                registerExecutable(condition, queriedOnly, jniAccessible, method);
                 found = true;
             }
         }
@@ -181,9 +188,9 @@ public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Cl
     }
 
     @Override
-    public boolean registerAllConstructors(ConfigurationCondition condition, boolean queriedOnly, Class<?> type) {
+    public boolean registerAllConstructors(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Class<?> type) {
         Executable[] methods = type.getDeclaredConstructors();
-        registerExecutable(condition, queriedOnly, methods);
+        registerExecutable(condition, queriedOnly, jniAccessible, methods);
         return methods.length > 0;
     }
 
@@ -199,7 +206,8 @@ public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Cl
     }
 
     @Override
-    public void registerMethod(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, String methodName, List<Class<?>> methodParameterTypes) throws NoSuchMethodException {
+    public void registerMethod(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, String methodName, List<Class<?>> methodParameterTypes, boolean jniAccessible)
+                    throws NoSuchMethodException {
         Class<?>[] parameterTypesArray = getParameterTypes(methodParameterTypes);
         Method method;
         try {
@@ -219,26 +227,31 @@ public class RegistryAdapter implements ReflectionConfigurationParserDelegate<Cl
                 throw e;
             }
         }
-        registerExecutable(condition, queriedOnly, method);
+        registerExecutable(condition, queriedOnly, jniAccessible, method);
     }
 
     @Override
-    public void registerConstructor(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, List<Class<?>> methodParameterTypes) throws NoSuchMethodException {
+    public void registerConstructor(ConfigurationCondition condition, boolean queriedOnly, Class<?> type, List<Class<?>> methodParameterTypes, boolean jniAccessible)
+                    throws NoSuchMethodException {
         Class<?>[] parameterTypesArray = getParameterTypes(methodParameterTypes);
-        registerExecutable(condition, queriedOnly, type.getDeclaredConstructor(parameterTypesArray));
+        registerExecutable(condition, queriedOnly, jniAccessible, type.getDeclaredConstructor(parameterTypesArray));
     }
 
     static Class<?>[] getParameterTypes(List<Class<?>> methodParameterTypes) {
         return methodParameterTypes.toArray(Class<?>[]::new);
     }
 
-    private void registerExecutable(ConfigurationCondition condition, boolean queriedOnly, Executable... executable) {
+    @SuppressWarnings("unused")
+    protected void registerExecutable(ConfigurationCondition condition, boolean queriedOnly, boolean jniAccessible, Executable... executable) {
         registry.register(condition, queriedOnly, executable);
     }
 
     @Override
     public void registerAsSerializable(ConfigurationCondition condition, Class<?> clazz) {
-        /* Serializable has no effect on JNI registrations */
+    }
+
+    @Override
+    public void registerAsJniAccessed(ConfigurationCondition condition, Class<?> clazz) {
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jni/JNIAccessFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jni/JNIAccessFeature.java
@@ -193,10 +193,10 @@ public class JNIAccessFeature implements Feature {
         runtimeSupport = new JNIRuntimeAccessibilitySupportImpl();
         ImageSingletons.add(RuntimeJNIAccessSupport.class, runtimeSupport);
 
-        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(JNI_KEY, true, runtimeSupport,
+        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(JNI_KEY, true, runtimeSupport, null,
                         access.getImageClassLoader());
         loadedConfigurations = ConfigurationParserUtils.parseAndRegisterConfigurationsFromCombinedFile(parser, access.getImageClassLoader(), "JNI");
-        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(null, false, runtimeSupport,
+        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(null, false, runtimeSupport, null,
                         access.getImageClassLoader());
         loadedConfigurations += ConfigurationParserUtils.parseAndRegisterConfigurations(legacyParser, access.getImageClassLoader(), "JNI", ConfigurationFiles.Options.JNIConfigurationFiles,
                         ConfigurationFiles.Options.JNIConfigurationResources, ConfigurationFile.JNI.getFileName());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jni/JNIAccessFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jni/JNIAccessFeature.java
@@ -97,6 +97,7 @@ import com.oracle.svm.hosted.meta.HostedType;
 import com.oracle.svm.hosted.meta.HostedUniverse;
 import com.oracle.svm.hosted.meta.KnownOffsetsFeature;
 import com.oracle.svm.hosted.meta.MaterializedConstantFields;
+import com.oracle.svm.hosted.reflect.ReflectionFeature;
 import com.oracle.svm.hosted.substitute.SubstitutionReflectivityFilter;
 import com.oracle.svm.util.ReflectionUtil;
 
@@ -181,7 +182,7 @@ public class JNIAccessFeature implements Feature {
     @Override
     public List<Class<? extends Feature>> getRequiredFeatures() {
         // Ensure that KnownOffsets is fully initialized before we access it
-        return List.of(KnownOffsetsFeature.class);
+        return List.of(KnownOffsetsFeature.class, ReflectionFeature.class);
     }
 
     @Override
@@ -193,10 +194,10 @@ public class JNIAccessFeature implements Feature {
         runtimeSupport = new JNIRuntimeAccessibilitySupportImpl();
         ImageSingletons.add(RuntimeJNIAccessSupport.class, runtimeSupport);
 
-        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(JNI_KEY, true, runtimeSupport, null,
+        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(JNI_KEY, true, runtimeSupport, null, null,
                         access.getImageClassLoader());
         loadedConfigurations = ConfigurationParserUtils.parseAndRegisterConfigurationsFromCombinedFile(parser, access.getImageClassLoader(), "JNI");
-        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(null, false, runtimeSupport, null,
+        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(JNI_KEY, false, runtimeSupport, null, null,
                         access.getImageClassLoader());
         loadedConfigurations += ConfigurationParserUtils.parseAndRegisterConfigurations(legacyParser, access.getImageClassLoader(), "JNI", ConfigurationFiles.Options.JNIConfigurationFiles,
                         ConfigurationFiles.Options.JNIConfigurationResources, ConfigurationFile.JNI.getFileName());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jni/JNIAccessFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jni/JNIAccessFeature.java
@@ -194,10 +194,10 @@ public class JNIAccessFeature implements Feature {
         runtimeSupport = new JNIRuntimeAccessibilitySupportImpl();
         ImageSingletons.add(RuntimeJNIAccessSupport.class, runtimeSupport);
 
-        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(JNI_KEY, true, runtimeSupport, null, null,
+        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(JNI_KEY, true, runtimeSupport, null, null, null,
                         access.getImageClassLoader());
         loadedConfigurations = ConfigurationParserUtils.parseAndRegisterConfigurationsFromCombinedFile(parser, access.getImageClassLoader(), "JNI");
-        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(JNI_KEY, false, runtimeSupport, null, null,
+        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(JNI_KEY, false, runtimeSupport, null, null, null,
                         access.getImageClassLoader());
         loadedConfigurations += ConfigurationParserUtils.parseAndRegisterConfigurations(legacyParser, access.getImageClassLoader(), "JNI", ConfigurationFiles.Options.JNIConfigurationFiles,
                         ConfigurationFiles.Options.JNIConfigurationResources, ConfigurationFile.JNI.getFileName());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionFeature.java
@@ -46,7 +46,9 @@ import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.c.function.CFunctionPointer;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.graalvm.nativeimage.impl.AnnotationExtractor;
+import org.graalvm.nativeimage.impl.RuntimeJNIAccessSupport;
 import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 import com.oracle.graal.pointsto.infrastructure.UniverseMetaAccess;
 import com.oracle.graal.pointsto.meta.AnalysisMethod;
@@ -91,7 +93,6 @@ import jdk.internal.reflect.Reflection;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaField;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
-import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 @AutomaticallyRegisteredFeature
 public class ReflectionFeature implements InternalFeature, ReflectionSubstitutionSupport {
@@ -263,11 +264,12 @@ public class ReflectionFeature implements InternalFeature, ReflectionSubstitutio
         aUniverse = access.getUniverse();
         reflectionData.duringSetup(access.getMetaAccess(), aUniverse);
         RuntimeSerializationSupport serializationSupport = ImageSingletons.lookup(RuntimeSerializationSupport.class);
+        RuntimeJNIAccessSupport jniSupport = ImageSingletons.lookup(RuntimeJNIAccessSupport.class);
 
-        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(REFLECTION_KEY, true, reflectionData, serializationSupport,
+        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(REFLECTION_KEY, true, reflectionData, serializationSupport, jniSupport,
                         access.getImageClassLoader());
         loadedConfigurations = ConfigurationParserUtils.parseAndRegisterConfigurationsFromCombinedFile(parser, access.getImageClassLoader(), "reflection");
-        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(null, false, reflectionData, serializationSupport,
+        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(REFLECTION_KEY, false, reflectionData, serializationSupport, jniSupport,
                         access.getImageClassLoader());
         loadedConfigurations += ConfigurationParserUtils.parseAndRegisterConfigurations(legacyParser, access.getImageClassLoader(), "reflection",
                         ConfigurationFiles.Options.ReflectionConfigurationFiles, ConfigurationFiles.Options.ReflectionConfigurationResources, ConfigurationFile.REFLECTION.getFileName());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionFeature.java
@@ -91,6 +91,7 @@ import jdk.internal.reflect.Reflection;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaField;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 @AutomaticallyRegisteredFeature
 public class ReflectionFeature implements InternalFeature, ReflectionSubstitutionSupport {
@@ -261,11 +262,12 @@ public class ReflectionFeature implements InternalFeature, ReflectionSubstitutio
         DuringSetupAccessImpl access = (DuringSetupAccessImpl) a;
         aUniverse = access.getUniverse();
         reflectionData.duringSetup(access.getMetaAccess(), aUniverse);
+        RuntimeSerializationSupport serializationSupport = ImageSingletons.lookup(RuntimeSerializationSupport.class);
 
-        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(REFLECTION_KEY, true, reflectionData,
+        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(REFLECTION_KEY, true, reflectionData, serializationSupport,
                         access.getImageClassLoader());
         loadedConfigurations = ConfigurationParserUtils.parseAndRegisterConfigurationsFromCombinedFile(parser, access.getImageClassLoader(), "reflection");
-        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(null, false, reflectionData,
+        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(null, false, reflectionData, serializationSupport,
                         access.getImageClassLoader());
         loadedConfigurations += ConfigurationParserUtils.parseAndRegisterConfigurations(legacyParser, access.getImageClassLoader(), "reflection",
                         ConfigurationFiles.Options.ReflectionConfigurationFiles, ConfigurationFiles.Options.ReflectionConfigurationResources, ConfigurationFile.REFLECTION.getFileName());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionFeature.java
@@ -55,6 +55,7 @@ import com.oracle.graal.pointsto.infrastructure.UniverseMetaAccess;
 import com.oracle.graal.pointsto.meta.AnalysisMethod;
 import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.svm.core.ParsingReason;
+import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.configure.ConfigurationFile;
@@ -266,7 +267,7 @@ public class ReflectionFeature implements InternalFeature, ReflectionSubstitutio
         reflectionData.duringSetup(access.getMetaAccess(), aUniverse);
         RuntimeProxyCreationSupport proxySupport = ImageSingletons.lookup(RuntimeProxyCreationSupport.class);
         RuntimeSerializationSupport serializationSupport = ImageSingletons.lookup(RuntimeSerializationSupport.class);
-        RuntimeJNIAccessSupport jniSupport = ImageSingletons.lookup(RuntimeJNIAccessSupport.class);
+        RuntimeJNIAccessSupport jniSupport = SubstrateOptions.JNI.getValue() ? ImageSingletons.lookup(RuntimeJNIAccessSupport.class) : null;
 
         ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(REFLECTION_KEY, true, reflectionData, proxySupport, serializationSupport, jniSupport,
                         access.getImageClassLoader());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionFeature.java
@@ -47,6 +47,7 @@ import org.graalvm.nativeimage.c.function.CFunctionPointer;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.graalvm.nativeimage.impl.AnnotationExtractor;
 import org.graalvm.nativeimage.impl.RuntimeJNIAccessSupport;
+import org.graalvm.nativeimage.impl.RuntimeProxyCreationSupport;
 import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
 import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
@@ -263,13 +264,14 @@ public class ReflectionFeature implements InternalFeature, ReflectionSubstitutio
         DuringSetupAccessImpl access = (DuringSetupAccessImpl) a;
         aUniverse = access.getUniverse();
         reflectionData.duringSetup(access.getMetaAccess(), aUniverse);
+        RuntimeProxyCreationSupport proxySupport = ImageSingletons.lookup(RuntimeProxyCreationSupport.class);
         RuntimeSerializationSupport serializationSupport = ImageSingletons.lookup(RuntimeSerializationSupport.class);
         RuntimeJNIAccessSupport jniSupport = ImageSingletons.lookup(RuntimeJNIAccessSupport.class);
 
-        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(REFLECTION_KEY, true, reflectionData, serializationSupport, jniSupport,
+        ReflectionConfigurationParser<Class<?>> parser = ConfigurationParserUtils.create(REFLECTION_KEY, true, reflectionData, proxySupport, serializationSupport, jniSupport,
                         access.getImageClassLoader());
         loadedConfigurations = ConfigurationParserUtils.parseAndRegisterConfigurationsFromCombinedFile(parser, access.getImageClassLoader(), "reflection");
-        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(REFLECTION_KEY, false, reflectionData, serializationSupport, jniSupport,
+        ReflectionConfigurationParser<Class<?>> legacyParser = ConfigurationParserUtils.create(REFLECTION_KEY, false, reflectionData, proxySupport, serializationSupport, jniSupport,
                         access.getImageClassLoader());
         loadedConfigurations += ConfigurationParserUtils.parseAndRegisterConfigurations(legacyParser, access.getImageClassLoader(), "reflection",
                         ConfigurationFiles.Options.ReflectionConfigurationFiles, ConfigurationFiles.Options.ReflectionConfigurationResources, ConfigurationFile.REFLECTION.getFileName());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/serialize/SerializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/serialize/SerializationFeature.java
@@ -107,6 +107,7 @@ import jdk.vm.ci.meta.ResolvedJavaType;
 public class SerializationFeature implements InternalFeature {
     final Set<Class<?>> capturingClasses = ConcurrentHashMap.newKeySet();
     private SerializationBuilder serializationBuilder;
+    private SerializationDenyRegistry serializationDenyRegistry;
     private int loadedConfigurations;
 
     @Override
@@ -115,13 +116,23 @@ public class SerializationFeature implements InternalFeature {
     }
 
     @Override
+    public void afterRegistration(AfterRegistrationAccess a) {
+        FeatureImpl.AfterRegistrationAccessImpl access = (FeatureImpl.AfterRegistrationAccessImpl) a;
+        ImageClassLoader imageClassLoader = access.getImageClassLoader();
+        ConfigurationTypeResolver typeResolver = new ConfigurationTypeResolver("serialization configuration", imageClassLoader);
+        serializationDenyRegistry = new SerializationDenyRegistry(typeResolver);
+        serializationBuilder = new SerializationBuilder(serializationDenyRegistry, access, typeResolver, ImageSingletons.lookup(ProxyRegistry.class));
+        /*
+         * The serialization builder registration has to happen after registration so the
+         * ReflectionFeature can access it when creating parsers during setup.
+         */
+        ImageSingletons.add(RuntimeSerializationSupport.class, serializationBuilder);
+    }
+
+    @Override
     public void duringSetup(DuringSetupAccess a) {
         FeatureImpl.DuringSetupAccessImpl access = (FeatureImpl.DuringSetupAccessImpl) a;
         ImageClassLoader imageClassLoader = access.getImageClassLoader();
-        ConfigurationTypeResolver typeResolver = new ConfigurationTypeResolver("serialization configuration", imageClassLoader);
-        SerializationDenyRegistry serializationDenyRegistry = new SerializationDenyRegistry(typeResolver);
-        serializationBuilder = new SerializationBuilder(serializationDenyRegistry, access, typeResolver, ImageSingletons.lookup(ProxyRegistry.class));
-        ImageSingletons.add(RuntimeSerializationSupport.class, serializationBuilder);
 
         Boolean strictConfiguration = ConfigurationFiles.Options.StrictConfiguration.getValue();
 
@@ -347,13 +358,13 @@ final class SerializationBuilder extends ConditionalConfigurationRegistry implem
     final SerializationSupport serializationSupport;
     private final SerializationDenyRegistry denyRegistry;
     private final ConfigurationTypeResolver typeResolver;
-    private final FeatureImpl.DuringSetupAccessImpl access;
+    private final FeatureImpl.AfterRegistrationAccessImpl access;
     private final Method disableSerialConstructorChecks;
     private final Method superHasAccessibleConstructor;
     private boolean sealed;
     private final ProxyRegistry proxyRegistry;
 
-    SerializationBuilder(SerializationDenyRegistry serializationDenyRegistry, FeatureImpl.DuringSetupAccessImpl access, ConfigurationTypeResolver typeResolver, ProxyRegistry proxyRegistry) {
+    SerializationBuilder(SerializationDenyRegistry serializationDenyRegistry, FeatureImpl.AfterRegistrationAccessImpl access, ConfigurationTypeResolver typeResolver, ProxyRegistry proxyRegistry) {
         this.access = access;
         Class<?> classDataSlotClazz = access.findClassByName("java.io.ObjectStreamClass$ClassDataSlot");
         this.descField = ReflectionUtil.lookupField(classDataSlotClazz, "desc");


### PR DESCRIPTION
These backports are required for Native Image to understand the new reachability metadata format introduced in the latest versions of GraalVM.

**This PR backports:**
- https://github.com/oracle/graal/pull/11839
- https://github.com/oracle/graal/pull/10215
- https://github.com/oracle/graal/pull/10213
- https://github.com/oracle/graal/pull/11066
- https://github.com/oracle/graal/pull/11240
- https://github.com/oracle/graal/pull/11313
- https://github.com/oracle/graal/pull/8822
- https://github.com/oracle/graal/pull/11210

**Conflicts:** There were no conflicts.

Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/217