### PR TITLE
[Backport] [Oracle GraalVM] [GR-69777] Backport to 23.1: Fix hash collisions in CompilationResultBuilder.buildLabelOffsets().

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/LIRInstruction.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/LIRInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -472,11 +472,6 @@ public abstract class LIRInstruction {
 
     public LIRInstructionClass<?> getLIRInstructionClass() {
         return instructionClass;
-    }
-
-    @Override
-    public int hashCode() {
-        return id;
     }
 
     public boolean needsClearUpperVectorRegisters() {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12179

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/236
