### PR TITLE
[Backport] [Oracle GraalVM] [GR-69950] Backport to 23.1: Restrict applicability of RemoveOpaqueValuePhase.

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/GraphState.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/nodes/GraphState.java
@@ -65,7 +65,8 @@ public final class GraphState {
     private static final EnumSet<StageFlag> LOW_TIER_MANDATORY_STAGES = EnumSet.of(
                     StageFlag.LOW_TIER_LOWERING,
                     StageFlag.EXPAND_LOGIC,
-                    StageFlag.ADDRESS_LOWERING);
+                    StageFlag.ADDRESS_LOWERING,
+                    StageFlag.REMOVE_OPAQUE_VALUES);
     private static final EnumSet<StageFlag> ENTERPRISE_MID_TIER_MANDATORY_STAGES = EnumSet.of(
                     StageFlag.VALUE_PROXY_REMOVAL,
                     StageFlag.SAFEPOINTS_INSERTION,
@@ -626,6 +627,7 @@ public final class GraphState {
         FIXED_READS,
         ADDRESS_LOWERING,
         FINAL_CANONICALIZATION,
+        REMOVE_OPAQUE_VALUES,
         TARGET_VECTOR_LOWERING,
     }
 

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/phases/common/CanonicalizerPhase.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/phases/common/CanonicalizerPhase.java
@@ -221,7 +221,9 @@ public class CanonicalizerPhase extends BasePhase<CoreProviders> {
 
     @Override
     public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
-        return NotApplicable.unlessRunBefore(this, StageFlag.FINAL_CANONICALIZATION, graphState);
+        return NotApplicable.ifAny(
+                        NotApplicable.unlessRunBefore(this, StageFlag.FINAL_CANONICALIZATION, graphState),
+                        NotApplicable.unlessRunBefore(this, StageFlag.REMOVE_OPAQUE_VALUES, graphState));
     }
 
     @Override


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/8571

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** Minor import section issue: 
```
import jdk.graal.compiler.nodes.GraphState.StageFlag;
->
import org.graalvm.compiler.nodes.GraphState.StageFlag;
```
<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/237
