### PR TITLE
Drop extra TruffleFromLibGraal.OnCompilationSuccess entrypoint added by GR-54673 backport

### DIFF
--- a/substratevm/src/com.oracle.svm.graal.hotspot.libgraal/src/com/oracle/svm/graal/hotspot/libgraal/truffle/HSTruffleCompilable.java
+++ b/substratevm/src/com.oracle.svm.graal.hotspot.libgraal/src/com/oracle/svm/graal/hotspot/libgraal/truffle/HSTruffleCompilable.java
@@ -37,7 +37,6 @@ import static com.oracle.svm.graal.hotspot.libgraal.truffle.HSTruffleCompilableG
 import static com.oracle.svm.graal.hotspot.libgraal.truffle.HSTruffleCompilableGen.callIsSameOrSplit;
 import static com.oracle.svm.graal.hotspot.libgraal.truffle.HSTruffleCompilableGen.callIsTrivial;
 import static com.oracle.svm.graal.hotspot.libgraal.truffle.HSTruffleCompilableGen.callOnCompilationFailed;
-import static com.oracle.svm.graal.hotspot.libgraal.truffle.HSTruffleCompilableGen.callOnCompilationSuccess;
 import static com.oracle.svm.graal.hotspot.libgraal.truffle.HSTruffleCompilableGen.callPrepareForCompilation;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.AsJavaConstant;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.CancelCompilation;
@@ -51,7 +50,6 @@ import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.I
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.IsSameOrSplit;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.IsTrivial;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.OnCompilationFailed;
-import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.OnCompilationSuccess;
 import static org.graalvm.jniutils.JNIMethodScope.env;
 import static org.graalvm.jniutils.JNIUtil.createString;
 
@@ -173,13 +171,6 @@ final class HSTruffleCompilable extends HSObject implements TruffleCompilable {
                 LibGraalObjectHandles.remove(serializedExceptionHandle);
             }
         }
-    }
-
-    @TruffleFromLibGraal(OnCompilationSuccess)
-    @Override
-    public void onCompilationSuccess(int compilationTier, boolean lastTier) {
-        JNIEnv env = env();
-        callOnCompilationSuccess(calls, env, getHandle(), compilationTier, lastTier);
     }
 
     @TruffleFromLibGraal(GetCompilableName)

--- a/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/hotspot/libgraal/TruffleFromLibGraal.java
+++ b/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/hotspot/libgraal/TruffleFromLibGraal.java
@@ -161,8 +161,6 @@ public @interface TruffleFromLibGraal {
         OnCodeInstallation,
         @Signature({void.class, Object.class, Supplier.class, boolean.class, boolean.class, boolean.class, boolean.class})
         OnCompilationFailed,
-        @Signature({void.class, Object.class, int.class, boolean.class})
-        OnCompilationSuccess,
         @Signature({void.class, Object.class, Object.class, Object.class})
         OnCompilationRetry,
         @Signature({void.class, Object.class, Object.class, String.class, boolean.class, boolean.class, int.class, long.class})

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/hotspot/libgraal/TruffleFromLibGraalEntryPoints.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/hotspot/libgraal/TruffleFromLibGraalEntryPoints.java
@@ -74,7 +74,6 @@ import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.I
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.Log;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.OnCodeInstallation;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.OnCompilationFailed;
-import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.OnCompilationSuccess;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.OnCompilationRetry;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.OnFailure;
 import static com.oracle.truffle.compiler.hotspot.libgraal.TruffleFromLibGraal.Id.OnGraalTierFinished;
@@ -339,11 +338,6 @@ final class TruffleFromLibGraalEntryPoints {
     @TruffleFromLibGraal(OnCompilationFailed)
     static void onCompilationFailed(Object compilable, Supplier<String> serializedException, boolean silent, boolean bailout, boolean permanentBailout, boolean graphTooBig) {
         ((TruffleCompilable) compilable).onCompilationFailed(serializedException, silent, bailout, permanentBailout, graphTooBig);
-    }
-
-    @TruffleFromLibGraal(OnCompilationSuccess)
-    static void onCompilationSuccess(Object compilable, int compilationTier, boolean lastTier) {
-        ((TruffleCompilable) compilable).onCompilationSuccess(compilationTier, lastTier);
     }
 
     @TruffleFromLibGraal(OnSuccess)


### PR DESCRIPTION

Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/246
