### PR TITLE
[Backport] [Oracle GraalVM] [GR-70295] Backport to 23.1: Use opaque placeholder value when deleting a VirtualFrameAccessorNode

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/nodes/frame/VirtualFrameAccessorNode.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/nodes/frame/VirtualFrameAccessorNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import static org.graalvm.compiler.nodeinfo.NodeSize.SIZE_0;
 import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.extended.OpaqueValueNode;
 import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.FixedGuardNode;
 import org.graalvm.compiler.nodes.FixedWithNextNode;
@@ -114,10 +115,11 @@ public abstract class VirtualFrameAccessorNode extends FixedWithNextNode impleme
             tool.delete();
         } else {
             /*
-             * Even though all usages will be eventually dead, we need to provide a valid
-             * replacement value for now.
+             * Even though all usages will be eventually dead, we need to provide a placeholder
+             * replacement value for now. This must be opaque to prevent transformations based on
+             * this value before the deletion takes effect.
              */
-            ConstantNode unusedValue = ConstantNode.forConstant(JavaConstant.defaultForKind(getStackKind()), tool.getMetaAccess());
+            ValueNode unusedValue = new OpaqueValueNode(ConstantNode.forConstant(JavaConstant.defaultForKind(getStackKind()), tool.getMetaAccess()));
             tool.addNode(unusedValue);
             tool.replaceWith(unusedValue);
         }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12182

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/258