### PR TITLE
[Backport] [Oracle GraalVM] [GR-73286] Backport to 23.1: Ensure that all isolates see a consistent global state.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/CEntryPointSnippets.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/CEntryPointSnippets.java
@@ -324,7 +324,13 @@ public final class CEntryPointSnippets extends SubstrateTemplates implements Sni
         Isolates.setCurrentStartTime();
 
         if (!firstIsolate) {
-            int state = Unsafe.getUnsafe().getInt(initStateAddr);
+            /*
+             * Always do a volatile read so that memory barriers are emitted. Together with the
+             * volatile write to initStateAddr below, this guarantees that subsequently created
+             * isolates see consistent values for the process-global state that was initialized by
+             * the first isolate.
+             */
+            int state = Unsafe.getUnsafe().getIntVolatile(null, initStateAddr);
             if (state != FirstIsolateInitStates.SUCCESSFUL) {
                 while (state == FirstIsolateInitStates.IN_PROGRESS) { // spin-wait for first isolate
                     PauseNode.pause();
@@ -378,6 +384,7 @@ public final class CEntryPointSnippets extends SubstrateTemplates implements Sni
         boolean success = PlatformNativeLibrarySupport.singleton().initializeBuiltinLibraries();
         if (firstIsolate) { // let other isolates (if any) initialize now
             int state = success ? FirstIsolateInitStates.SUCCESSFUL : FirstIsolateInitStates.FAILED;
+            /* Do a volatile write to ensure that other threads see a consistent state. */
             Unsafe.getUnsafe().putIntVolatile(null, initStateAddr, state);
         }
 


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12921

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were minor conflicts in java import section - skipped as not applicable.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/255
