### PR TITLE
[Backport] [Oracle GraalVM] [GR-72626] Backport to 23.1: Implement JVM_ArrayCopy on Darwin.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationPrefs.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationPrefs.java
@@ -98,6 +98,8 @@ public class JNIRegistrationPrefs extends JNIRegistrationUtil implements Interna
         if (isDarwin()) {
             /* Darwin allocates a string array from native code */
             RuntimeJNIAccess.register(String[].class);
+            /* Called by libprefs on Darwin */
+            RuntimeJNIAccess.register(method(access, "java.lang.System", "arraycopy", Object.class, int.class, Object.class, int.class, int.class));
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
+++ b/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
@@ -277,6 +277,19 @@ JNIEXPORT jlong JNICALL Java_jdk_internal_misc_VM_getNanoTimeAdjustment(void *en
     return JVM_GetNanoTimeAdjustment(env, ignored, offset_secs);
 }
 
+JNIEXPORT void JNICALL JVM_ArrayCopy(JNIEnv *env, jclass ignored, jobject src, jint src_pos, jobject dst, jint dst_pos, jint length) {
+    jclass systemClass = (*env)->FindClass(env, "java/lang/System");
+    if (systemClass != NULL && !(*env)->ExceptionCheck(env)) {
+        jmethodID arraycopy = (*env)->GetStaticMethodID(env, systemClass, "arraycopy", "(Ljava/lang/Object;ILjava/lang/Object;II)V");
+        if (arraycopy != NULL && !(*env)->ExceptionCheck(env)) {
+            (*env)->CallStaticVoidMethod(env, systemClass, arraycopy, src, src_pos, dst, dst_pos, length);
+            return;
+        }
+    }
+
+    (*env)->FatalError(env, "JVM_ArrayCopy called: Could not find System#arraycopy");
+}
+
 JNIEXPORT void JNICALL JVM_Halt(int retcode) {
     exit(retcode);
 }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/9285

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/253