### PR TITLE
[Backport] [Oracle GraalVM] [GR-73342] Backport to 23.1: Allow generation of SSE V128_DOUBLE stores

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/asm/amd64/AMD64Assembler.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/asm/amd64/AMD64Assembler.java
@@ -882,6 +882,7 @@ public class AMD64Assembler extends AMD64BaseAssembler {
         // MOVSS and MOVSD are the same opcode, just with different operand size prefix
         public static final SSEMROp MOVSS = new SSEMROp("MOVSS",      P_0F, 0x11, PreferredNDS.SRC,  OpAssertion.SingleAssertion);
         public static final SSEMROp MOVSD = new SSEMROp("MOVSD",      P_0F, 0x11, PreferredNDS.SRC,  OpAssertion.DoubleAssertion);
+        public static final SSEMROp MOVUPD = new SSEMROp("MOVUPD", 0x66, P_0F, 0x11, PreferredNDS.NONE, OpAssertion.PackedDoubleAssertion);
         // @formatter:on
 
         private final PreferredNDS preferredNDS;

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1325,6 +1326,9 @@ public class AMD64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implemen
                 break;
             case DOUBLE:
                 getLIRGen().append(new AMD64BinaryConsumer.MemoryMROp(SSEMROp.MOVSD, SD, address, value, state));
+                break;
+            case V128_DOUBLE:
+                getLIRGen().append(new AMD64BinaryConsumer.MemoryMROp(SSEMROp.MOVUPD, PD, address, value, state));
                 break;
             default:
                 throw GraalError.shouldNotReachHereUnexpectedValue(kind); // ExcludeFromJacocoGeneratedReport


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12945

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 

- CONFLICT (modify/delete): compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/asm/amd64/AMD64Assembler.java
  - automatic merge failed (AMD64Assembler is actually in jdk.internal.vm.compiler) - applied manually
- CONFLICT (content): Merge conflict in compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
  - minor conflict in a Copyright header

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/250
