### PR TITLE
[Backport] [Oracle GraalVM] [GR-69335] Backport to 23.1: Fix pending JNI exception leak in native-image-agent.

### DIFF
--- a/substratevm/src/com.oracle.svm.jvmtiagentbase/src/com/oracle/svm/jvmtiagentbase/Support.java
+++ b/substratevm/src/com.oracle.svm.jvmtiagentbase/src/com/oracle/svm/jvmtiagentbase/Support.java
@@ -211,8 +211,11 @@ public final class Support {
     public static String getClassNameOr(JNIEnvironment env, JNIObjectHandle clazz, String forNullHandle, String forNullNameOrException) {
         if (clazz.notEqual(nullHandle())) {
             JNIObjectHandle clazzName = callObjectMethod(env, clazz, JvmtiAgentBase.singleton().handles().javaLangClassGetName);
+            if (clearException(env)) {
+                return forNullNameOrException;
+            }
             String result = Support.fromJniString(env, clazzName);
-            if (result == null || clearException(env)) {
+            if (result == null) {
                 result = forNullNameOrException;
             }
             return result;


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12097

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/260
