### PR TITLE
[Backport] [Oracle GraalVM] [GR-69291] Backport to 23.1: Do not inline hasNextTier in parsing.

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/truffle/test/HostInliningTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/truffle/test/HostInliningTest.java
@@ -148,6 +148,23 @@ public class HostInliningTest extends TruffleCompilerImplTest {
         runTest("testThrow");
         runTest("testRangeCheck");
         runTest("testImplicitCast");
+        runTest("testBCDSLPrologIfVersion");
+    }
+
+    /*
+     * Test for GR-69170
+     */
+    @SuppressWarnings("unused")
+    @BytecodeInterpreterSwitch
+    static Object testBCDSLPrologIfVersion(int value) {
+        Object o = null;
+        if (!CompilerDirectives.inInterpreter() && CompilerDirectives.hasNextTier()) {
+            GraalDirectives.deoptimize();
+            o = new Object();
+        }
+        // must be inlined
+        trivialMethod();
+        return o;
     }
 
     @SuppressWarnings("try")

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/host/HostInliningPhase.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/host/HostInliningPhase.java
@@ -1342,6 +1342,7 @@ public class HostInliningPhase extends AbstractInliningPhase {
                         info.isTruffleBoundary() ||
                         types.isInInterpreter(callee) ||
                         types.isInInterpreterFastPath(callee) ||
+                        types.isHasNextTier(callee) ||
                         types.isTransferToInterpreterMethod(callee));
     }
 

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/host/TruffleKnownHostTypes.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/host/TruffleKnownHostTypes.java
@@ -51,6 +51,7 @@ public final class TruffleKnownHostTypes extends AbstractKnownTruffleTypes {
     public final ResolvedJavaMethod CompilerDirectives_transferToInterpreter = findMethod(CompilerDirectives, "transferToInterpreter");
     public final ResolvedJavaMethod CompilerDirectives_transferToInterpreterAndInvalidate = findMethod(CompilerDirectives, "transferToInterpreterAndInvalidate");
     public final ResolvedJavaMethod CompilerDirectives_inInterpreter = findMethod(CompilerDirectives, "inInterpreter");
+    public final ResolvedJavaMethod CompilerDirectives_hasNextTier = findMethod(CompilerDirectives, "hasNextTier");
 
     public final ResolvedJavaType HostCompilerDirectives = lookupTypeCached("com.oracle.truffle.api.HostCompilerDirectives");
     public final ResolvedJavaMethod HostCompilerDirectives_inInterpreterFastPath = findMethod(HostCompilerDirectives, "inInterpreterFastPath");
@@ -73,6 +74,10 @@ public final class TruffleKnownHostTypes extends AbstractKnownTruffleTypes {
      */
     public boolean isInInterpreterFastPath(ResolvedJavaMethod method) {
         return method.equals(HostCompilerDirectives_inInterpreterFastPath);
+    }
+
+    public boolean isHasNextTier(ResolvedJavaMethod method) {
+        return method.equals(CompilerDirectives_hasNextTier);
     }
 
     /**


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12088

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** Minor merge issues

<details >

Merge issue: different context, missing testNativeCall test on graalvm-community-jdk21u branch
```
<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/truffle/test/HostInliningTest.java
=======
        runTest("testNativeCall");
        runTest("testBCDSLPrologIfVersion");
    }

    /*
     * Test for GR-69170
     */
    @BytecodeInterpreterSwitch
    static Object testBCDSLPrologIfVersion(int value) {
        Object o = null;
        if (!CompilerDirectives.inInterpreter() && CompilerDirectives.hasNextTier()) {
            GraalDirectives.deoptimize();
            o = new Object();
        }
        // must be inlined
        trivialMethod();
        return o;
>>>>>>> 3a3230502ee (do not inline hasNextTier in parsing, is required for correct host):compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/truffle/test/HostInliningTest.java
```

Merge issue: different context, missing types  on graalvm-community-jdk21u branch
```
<<<<<<< HEAD:compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/truffle/compiler/host/TruffleKnownHostTypes.java
=======
    public final ResolvedJavaMethod CompilerDirectives_hasNextTier = findMethod(CompilerDirectives, "hasNextTier");
    public final ResolvedJavaType TruffleBoundary = lookupType("com.oracle.truffle.api.CompilerDirectives$TruffleBoundary");
    public final ResolvedJavaType BytecodeInterpreterSwitch = lookupType("com.oracle.truffle.api.HostCompilerDirectives$BytecodeInterpreterSwitch");
    public final ResolvedJavaType BytecodeInterpreterSwitchBoundary = lookupType("com.oracle.truffle.api.HostCompilerDirectives$BytecodeInterpreterSwitchBoundary");
    public final ResolvedJavaType InliningCutoff = lookupType("com.oracle.truffle.api.HostCompilerDirectives$InliningCutoff");
>>>>>>> 3a3230502ee (do not inline hasNextTier in parsing, is required for correct host):compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/truffle/host/TruffleKnownHostTypes.java
```
</details>

Additional change to address CI complaint _"Parameter value not used"_:
```diff
   /*
     * Test for GR-69170
     */
+   @SuppressWarnings("unused")
    @BytecodeInterpreterSwitch
    static Object testBCDSLPrologIfVersion(int value) {
        Object o = null;
        if (!CompilerDirectives.inInterpreter() && CompilerDirectives.hasNextTier()) {
            GraalDirectives.deoptimize();
            o = new Object();
        }
        // must be inlined
        trivialMethod();
        return o;
    }
```


<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/252