### PR TITLE
[Backport] [Oracle GraalVM] [GR-73211] Backport to 23.1: Verify that the image heap is mapped correctly.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -41,6 +41,7 @@ import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.MemoryWalker;
 import com.oracle.svm.core.NeverInline;
@@ -848,6 +849,34 @@ public final class HeapImpl extends Heap {
     private static Descriptor getTlabUnsafe(IsolateThread thread) {
         assert SubstrateDiagnostics.isFatalErrorHandlingThread() : "can cause crashes, so it may only be used while printing diagnostics";
         return ThreadLocalAllocation.getTlab(thread);
+    }
+
+    @Override
+    @Uninterruptible(reason = "Called during early startup.")
+    public boolean verifyImageHeapMapping() {
+        ImageHeapInfo info = HeapImpl.getImageHeapInfo();
+        writeToEachChunk(info.getFirstWritableAlignedChunk(), WordFactory.nullPointer());
+        return true;
+    }
+
+    @Uninterruptible(reason = "Called during early startup.")
+    private static void writeToEachChunk(HeapChunk.Header<?> firstChunk, HeapChunk.Header<?> lastChunk) {
+        HeapChunk.Header<?> curChunk = firstChunk;
+        while (curChunk.isNonNull()) {
+            Pointer begin = (Pointer) curChunk;
+            Pointer end = HeapChunk.getTopPointer(curChunk).subtract(1);
+
+            byte val = begin.readByte(0);
+            begin.writeByte(0, val);
+
+            val = end.readByte(0);
+            end.writeByte(0, val);
+
+            if (curChunk.equal(lastChunk)) {
+                break;
+            }
+            curChunk = HeapChunk.getNext(curChunk);
+        }
     }
 
     private static class DumpHeapSettingsAndStatistics extends DiagnosticThunk {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ImageHeapWalker.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ImageHeapWalker.java
@@ -160,11 +160,6 @@ abstract class MemoryWalkerAccessBase implements MemoryWalker.NativeImageHeapReg
     }
 
     @Override
-    public UnsignedWord getStart(ImageHeapInfo info) {
-        return Word.objectToUntrackedPointer(getFirstObject(info));
-    }
-
-    @Override
     public UnsignedWord getSize(ImageHeapInfo info) {
         Pointer firstStart = Word.objectToUntrackedPointer(getFirstObject(info));
         if (firstStart.isNull()) { // no objects
@@ -195,10 +190,6 @@ abstract class MemoryWalkerAccessBase implements MemoryWalker.NativeImageHeapReg
         boolean alignedChunks = !hasHugeObjects;
         return ImageHeapWalker.walkPartitionInline(getFirstObject(region), getLastObject(region), visitor, alignedChunks);
     }
-
-    protected abstract Object getFirstObject(ImageHeapInfo info);
-
-    protected abstract Object getLastObject(ImageHeapInfo info);
 }
 
 final class ReadOnlyPrimitiveMemoryWalkerAccess extends MemoryWalkerAccessBase {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Isolates.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Isolates.java
@@ -51,6 +51,12 @@ public class Isolates {
     public static final String IMAGE_HEAP_WRITABLE_BEGIN_SYMBOL_NAME = "__svm_heap_writable_begin";
     public static final String IMAGE_HEAP_WRITABLE_END_SYMBOL_NAME = "__svm_heap_writable_end";
 
+    /*
+     * The values that are stored in the image heap symbols are either unaligned or at most aligned
+     * to the build-time page size. When using these values at run-time (e.g., for changing the
+     * memory access protection of the image heap), it may be necessary to round them to a multiple
+     * of the run-time page size.
+     */
     public static final CGlobalData<Word> IMAGE_HEAP_BEGIN = CGlobalDataFactory.forSymbol(IMAGE_HEAP_BEGIN_SYMBOL_NAME);
     public static final CGlobalData<Word> IMAGE_HEAP_END = CGlobalDataFactory.forSymbol(IMAGE_HEAP_END_SYMBOL_NAME);
     public static final CGlobalData<Word> IMAGE_HEAP_RELOCATABLE_BEGIN = CGlobalDataFactory.forSymbol(IMAGE_HEAP_RELOCATABLE_BEGIN_SYMBOL_NAME);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/MemoryWalker.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/MemoryWalker.java
@@ -58,7 +58,9 @@ public final class MemoryWalker {
     /** A set of access methods for visiting regions of the native image heap. */
     public interface NativeImageHeapRegionAccess<T> {
 
-        UnsignedWord getStart(T region);
+        Object getFirstObject(T region);
+
+        Object getLastObject(T region);
 
         UnsignedWord getSize(T region);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/CEntryPointSnippets.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/CEntryPointSnippets.java
@@ -88,6 +88,7 @@ import com.oracle.svm.core.graal.nodes.CEntryPointEnterNode;
 import com.oracle.svm.core.graal.nodes.CEntryPointLeaveNode;
 import com.oracle.svm.core.graal.nodes.CEntryPointUtilityNode;
 import com.oracle.svm.core.graal.nodes.WriteCurrentVMThreadNode;
+import com.oracle.svm.core.heap.Heap;
 import com.oracle.svm.core.heap.PhysicalMemory;
 import com.oracle.svm.core.heap.ReferenceHandler;
 import com.oracle.svm.core.heap.ReferenceHandlerThread;
@@ -244,6 +245,7 @@ public final class CEntryPointSnippets extends SubstrateTemplates implements Sni
     @Uninterruptible(reason = "Thread state not yet set up.")
     @NeverInline(value = "Ensure this code cannot rise above where heap base is set.")
     private static int createIsolate0(Isolate isolate, CEntryPointCreateIsolateParameters parameters, CLongPointer parsedArgs) {
+        assert Heap.getHeap().verifyImageHeapMapping();
         IsolateArgumentParser.persistOptions(parameters, parsedArgs);
         IsolateListenerSupport.singleton().afterCreateIsolate(isolate);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Heap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Heap.java
@@ -56,6 +56,10 @@ public abstract class Heap {
     protected Heap() {
     }
 
+    /** Verifies that the image heap was mapped correctly. */
+    @Uninterruptible(reason = "Called during startup.")
+    public abstract boolean verifyImageHeapMapping();
+
     /**
      * Notifies the heap that a new thread was attached to the VM. This allows to initialize
      * heap-specific datastructures, e.g., the TLAB.

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/ImageHeapProvider.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/ImageHeapProvider.java
@@ -31,24 +31,38 @@ import org.graalvm.word.Pointer;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.UnsignedWord;
 
+import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.c.function.CEntryPointErrors;
 import com.oracle.svm.core.heap.Heap;
 
 /**
  * Provides new instances of the image heap for creating isolates. The same image heap provider
  * implementation can be shared by different garbage collectors.
- * <p>
- * When a heap base is used, then the image heap is always mapped in a way that the memory at the
- * heap base is protected and marked as inaccessible. Depending on the specific scenario, that
- * memory may or may not be part of the Native Image file (see
- * {@link Heap#getImageHeapNullRegionSize()} and {@link Heap#getImageHeapOffsetInAddressSpace()} for
- * more details). This is done regardless of the used GC, platform, or CPU architecture:
+ *
+ * If {@link SubstrateOptions#SpawnIsolates} is disabled, the image heap is loaded and mapped by the
+ * operating system instead of an image heap provider (see {@link OSCommittedMemoryProvider}). Note
+ * that this mode is deprecated and not covered by the documentation below.
+ *
+ * If {@link SubstrateOptions#SpawnIsolates} is enabled, a heap base is used and the image heap is
+ * explicitly mapped into a contiguous address space. Here is the typical memory layout of a mapped
+ * image heap at run-time:
  *
  * <pre>
- * | protected memory | image heap |
+ * |---------------------------------------------------------------------------------------|
+ * | protected memory |          read-only          |    writable   | read-only (optional) |
+ * |---------------------------------------------------------------------------------------|
+ * |                  | normal objects | relocatable data |         normal objects         |
+ * |---------------------------------------------------------------------------------------|
  * ^
  * heapBase
  * </pre>
+ *
+ * The memory at the heap base is explicitly marked as inaccessible (see
+ * {@link Heap#getImageHeapOffsetInAddressSpace()} for more details). Accesses to it will result in
+ * a segfault.
+ *
+ * Note that the relocatable data may overlap with both the read-only and writable part of the image
+ * heap. Besides that, parts of the read-only relocatable data may be writable at run-time.
  */
 public interface ImageHeapProvider {
     @Fold


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/10098

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 
<details>
<summary>minor merge issues</summary>

```
<<<<<<< HEAD
    private static int createIsolate0(Isolate isolate, CEntryPointCreateIsolateParameters parameters, CLongPointer parsedArgs) {
        IsolateArgumentParser.persistOptions(parameters, parsedArgs);
=======
    private static int createIsolate0(Isolate isolate, IsolateArguments arguments) {
        assert Heap.getHeap().verifyImageHeapMapping();
        IsolateArgumentParser.singleton().persistOptions(arguments);
>>>>>>> d604c455903 (Verify that the image heap is mapped correctly.)

<<<<<<< HEAD
 * <p>
 * When a heap base is used, then the image heap is always mapped in a way that the memory at the
 * heap base is protected and marked as inaccessible. Depending on the specific scenario, that
 * memory may or may not be part of the Native Image file (see
 * {@link Heap#getImageHeapNullRegionSize()} and {@link Heap#getImageHeapOffsetInAddressSpace()} for
 * more details). This is done regardless of the used GC, platform, or CPU architecture:
=======
 *
 * If {@link SubstrateOptions#SpawnIsolates} is disabled, the image heap is loaded and mapped by the
 * operating system instead of an image heap provider (see {@link OSCommittedMemoryProvider}). Note
 * that this mode is deprecated and not covered by the documentation below.
 *
 * If {@link SubstrateOptions#SpawnIsolates} is enabled, a heap base is used and the image heap is
 * explicitly mapped into a contiguous address space. Here is the typical memory layout of a mapped
 * image heap at run-time:
>>>>>>> d604c455903 (Verify that the image heap is mapped correctly.)
```

</details>

**Build issues:**
1. HeapImpl.getImageHeapInfos() is not available in 21u - introduced in [ccb39e4e](https://github.com/oracle/graal/commit/ccb39e4e): Turn ImageHeapInfo into a MultiLayeredImageSingleton
2.  ImageHeapInfo.getLastWritableUnalignedChunk() is not available in 21u - introduced in [5d56813c](https://github.com/oracle/graal/commit/5d56813c), Merge image heap primitive and reference partitions 

Fix: use HeapImpl.getImageHeapInfo() instead of getImageHeapInfos(), and skip unaligned chunk verification.
```diff
-        for (ImageHeapInfo info : HeapImpl.getImageHeapInfos()) {
-            /* Read & write some data at the beginning and end of each writable chunk. */
-            writeToEachChunk(info.getFirstWritableAlignedChunk(), WordFactory.nullPointer());
-            writeToEachChunk(info.getFirstWritableUnalignedChunk(), info.getLastWritableUnalignedChunk());
-        }
+        /* Read & write some data at the beginning and end of each writable chunk. */
+        ImageHeapInfo info = HeapImpl.getImageHeapInfo();
+        writeToEachChunk(info.getFirstWritableAlignedChunk(), WordFactory.nullPointer());
```

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/261