### PR TITLE
[CI] Enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly" # Options: daily, weekly, monthly
+    groups:
+      # Group updates to avoid PR spam
+      actions-updates:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "[CI] Update GitHub Actions"
+      include: "scope"


### PR DESCRIPTION
Enable dependabot to open PRs for updating actions used in our CI workflows.