### PR TITLE
[CI] Pin github actions to commit SHA IDs instead of tags [skip ci]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,25 +119,25 @@ jobs:
       MX_RUNS_STYLE: ${{ contains(matrix.env.GATE_TAGS, 'style') || matrix.env.GATE_TAGS == '' }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.ref }} # Lock ref to current branch to avoid fetching others
         fetch-depth: "${{ env.MX_RUNS_STYLE && '0' || '1' }}" # The style gate needs the full commit history for checking copyright years
     - name: Determine mx version
       run: echo "MX_VERSION=$(jq -r '.mx_version' common.json)" >> ${GITHUB_ENV}
     - name: Checkout graalvm/mx
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: graalvm/mx.git
         ref: ${{ env.MX_VERSION }}
         fetch-depth: 1
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.8'
     - name: Update mx cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -37,18 +37,18 @@ jobs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         fetch-depth: 1
     - name: Checkout graalvm/mx
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         repository: graalvm/mx.git
         fetch-depth: 1
         ref: master
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: '3.8'
     - name: Get latest Quarkus release
@@ -58,13 +58,13 @@ jobs:
         curl --output quarkus.tgz -sL https://api.github.com/repos/quarkusio/quarkus/tarball/$QUARKUS_VERSION
         mkdir ${QUARKUS_PATH}
         tar xf quarkus.tgz -C ${QUARKUS_PATH} --strip-components=1
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.mx
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
@@ -89,12 +89,12 @@ jobs:
       shell: bash
       run: tar -czvf graalvm.tgz -C $(dirname ${GRAALVM_HOME}) $(basename ${GRAALVM_HOME})
     - name: Persist GraalVM build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: graalvm
         path: graalvm.tgz
     - name: Use JDK 17 for Quarkus build
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: temurin
         java-version: 17
@@ -112,7 +112,7 @@ jobs:
       shell: bash
       run: tar -czvf maven-repo.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: maven-repo
         path: maven-repo.tgz
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: Download GraalVM build
         if: startsWith(matrix.os-name, 'ubuntu')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: graalvm
           path: .
@@ -151,7 +151,7 @@ jobs:
         run: ${QUARKUS_PATH}/.github/ci-prerequisites.sh
       - name: Download Maven Repo
         if: startsWith(matrix.os-name, 'ubuntu')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: maven-repo
           path: .
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
       - name: Use JDK 17 for Quarkus build
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 17
@@ -178,7 +178,7 @@ jobs:
         shell: bash
         run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         if: failure()
         with:
           name: test-reports-native-${{matrix.category}}


### PR DESCRIPTION
Increase security by avoiding the use of mutable tags

tags mapped to IDs using the following script and manually verified:

```bash

set -euo pipefail

declare -A sha_cache

get_sha() {
    local repo="$1" tag="$2"
    local key="${repo}@${tag}"

    if [[ -n "${sha_cache[$key]+x}" ]]; then
        echo "${sha_cache[$key]}"
        return 0
    fi

    local sha
    if sha=$(gh api "repos/${repo}/commits/${tag}" --jq '.sha' 2>/dev/null); then
        sha_cache[$key]="$sha"
        echo "$sha"
    else
        return 1
    fi
}

if [[ $# -gt 0 ]]; then
    mapfile -t files < <(printf '%s\n' "$@")
else
    mapfile -t files < <(find .github -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
fi

if [[ ${#files[@]} -eq 0 ]]; then
    echo "No workflow files found." >&2
    exit 1
fi

for file in "${files[@]}"; do
    mapfile -t actions < <(
        grep -oP 'uses:\s+\Kactions/[^@\s]+@v[0-9][^\s#]*' "$file" 2>/dev/null | sort -u
    )

    [[ ${#actions[@]} -eq 0 ]] && continue

    echo "Processing: $file"

    for action in "${actions[@]}"; do
        repo="${action%@*}"
        tag="${action#*@}"

        sha=$(get_sha "$repo" "$tag") || {
            echo "  ⚠ Could not fetch SHA for ${action}" >&2
            continue
        }

        echo "  ${action} → ${sha}"
        sed -i "s|${action}|${repo}@${sha} # ${tag}|g" "$file"
    done
done

echo "Done."
```

