### PR TITLE
[Backport] [Oracle GraalVM] [GR-74238] Backport to 23.1: Update simdjson to 4.3.1

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/aarch64/AArch64CalcStringAttributesOp.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/aarch64/AArch64CalcStringAttributesOp.java
@@ -532,7 +532,7 @@ public final class AArch64CalcStringAttributesOp extends AArch64ComplexVectorOp 
      * One Instruction Per Byte</a> by John Keiser and Daniel Lemire, and the author's
      * implementation in <a href=
      * "https://github.com/simdjson/simdjson/blob/d996ffc49423cee75922c30432323288c34f3c04/src/generic/stage1/utf8_lookup4_algorithm.h">
-     * the simdjson library</a>.
+     * the simdjson library</a>. Follow-up changes made sure this is compatible with simdjson 4.3.1.
      *
      * @see <a href="https://github.com/simdjson/simdjson">https://github.com/simdjson/simdjson</a>
      * @see <a href="https://lemire.me/blog/2020/10/20/ridiculously-fast-unicode-utf-8-validation/">

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64CalcStringAttributesOp.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/lir/amd64/AMD64CalcStringAttributesOp.java
@@ -582,7 +582,7 @@ public final class AMD64CalcStringAttributesOp extends AMD64ComplexVectorOp {
      * One Instruction Per Byte</a> by John Keiser and Daniel Lemire, and the author's
      * implementation in <a href=
      * "https://github.com/simdjson/simdjson/blob/d996ffc49423cee75922c30432323288c34f3c04/src/generic/stage1/utf8_lookup4_algorithm.h">
-     * the simdjson library</a>.
+     * the simdjson library</a>. Follow-up changes made sure this is compatible with simdjson 4.3.1.
      *
      * @see <a href="https://github.com/simdjson/simdjson">https://github.com/simdjson/simdjson</a>
      * @see <a href="https://lemire.me/blog/2020/10/20/ridiculously-fast-unicode-utf-8-validation/">


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13053 (commit [#3](https://github.com/oracle/graal/pull/13053/changes/f660521d039297c127a4b192ddc6ba59430b0b0a))

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
- minor conflict: add a line, not just a number update

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/286

Related change in graalvm-community-jdk25u: https://github.com/graalvm/graalvm-community-jdk25u/pull/87