### PR TITLE
[Backport] [Oracle GraalVM] [GR-73380] Backport to 23.1: Don't return Number objects directly to host if they are also TruffleObject objects.

### DIFF
--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ValueAPITest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ValueAPITest.java
@@ -72,6 +72,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.Serial;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -125,6 +126,7 @@ import org.junit.Test;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
@@ -2648,4 +2650,122 @@ public class ValueAPITest {
         assertEquals((Character) (char) 1, val.as(Character.class));
     }
 
+    @Test
+    public void testTruffleNumberObject() {
+        try (Context c = Context.create()) {
+            Value val = c.asValue(new TruffleByteObject((byte) 42));
+            Object numberObj = val.as(Object.class);
+            assertTrue(numberObj instanceof Byte);
+            assertEquals(42, (byte) numberObj);
+        }
+    }
+
+    @ExportLibrary(InteropLibrary.class)
+    @SuppressWarnings({"static-method"})
+    static class TruffleByteObject extends Number implements TruffleObject {
+
+        @Serial private static final long serialVersionUID = 1922664232217003500L;
+
+        private final byte byteValue;
+
+        TruffleByteObject(byte byteValue) {
+            this.byteValue = byteValue;
+        }
+
+        @ExportMessage
+        boolean isNumber() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInByte() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInShort() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInInt() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInLong() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInFloat() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInDouble() {
+            return true;
+        }
+
+        @ExportMessage
+        boolean fitsInBigInteger() {
+            return true;
+        }
+
+        @ExportMessage
+        byte asByte() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        short asShort() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        int asInt() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        long asLong() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        float asFloat() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        double asDouble() {
+            return byteValue;
+        }
+
+        @ExportMessage
+        @TruffleBoundary
+        BigInteger asBigInteger() {
+            return BigInteger.valueOf(byteValue);
+        }
+
+        @Override
+        public int intValue() {
+            return byteValue;
+        }
+
+        @Override
+        public long longValue() {
+            return byteValue;
+        }
+
+        @Override
+        public float floatValue() {
+            return byteValue;
+        }
+
+        @Override
+        public double doubleValue() {
+            return byteValue;
+        }
+    }
 }

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostUtil.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostUtil.java
@@ -45,6 +45,7 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 
 /**
@@ -115,7 +116,7 @@ final class HostUtil {
                     return delegate;
                 }
             }
-            if (value instanceof Number) {
+            if (value instanceof Number && !(value instanceof TruffleObject)) {
                 return value;
             } else if (interop.fitsInByte(value)) {
                 return interop.asByte(value);


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12946

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
- Automatic merge failed for ValueAPITest.java due to different context - inserted new tests manually

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/284
