### PR TITLE
[Backport] [GR-75580] Remove NO_TRANSITION from dlsym(...)

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Dlfcn.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Dlfcn.java
@@ -73,11 +73,24 @@ public class Dlfcn {
     @CFunction
     public static native int dlclose(PointerBase handle);
 
-    @CFunction(transition = Transition.NO_TRANSITION)
+    @CFunction
     public static native <T extends PointerBase> T dlsym(PointerBase handle, CCharPointer name);
 
     @CFunction
     public static native CCharPointer dlerror();
+
+    @CContext(PosixDirectives.class)
+    @CLibrary("dl")
+    public static class NoTransitions {
+        /**
+         * Only use this variant from code that must remain fully uninterruptible, such as early
+         * startup code before Java thread state is available. All ordinary runtime symbol lookups
+         * must use {@link Dlfcn#dlsym(PointerBase, CCharPointer)} because dlsym can block on the
+         * dynamic loader lock.
+         */
+        @CFunction(value = "dlsym", transition = Transition.NO_TRANSITION)
+        public static native <T extends PointerBase> T dlsym(PointerBase handle, CCharPointer name);
+    }
 
     @CStruct
     public interface Dl_info extends PointerBase {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13627

**Conflicts:**

- no conflicts
 
<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/298