### PR TITLE
Handle new intrinsics introduced to 21.0.13 with JDK-8389704 and JDK-8349721

### DIFF
--- a/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/hotspot/test/HotSpotCryptoSubstitutionTest.java
+++ b/compiler/src/jdk.internal.vm.compiler.test/src/org/graalvm/compiler/hotspot/test/HotSpotCryptoSubstitutionTest.java
@@ -47,6 +47,7 @@ import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.extended.ForeignCallNode;
 import org.graalvm.compiler.replacements.SnippetSubstitutionNode;
 import org.graalvm.compiler.replacements.nodes.AESNode;
+import org.graalvm.compiler.replacements.nodes.MessageDigestNode;
 import org.graalvm.compiler.replacements.nodes.CipherBlockChainingAESNode;
 import org.graalvm.compiler.replacements.nodes.CounterModeAESNode;
 import org.junit.Assert;
@@ -417,7 +418,18 @@ public class HotSpotCryptoSubstitutionTest extends HotSpotGraalCompilerTest {
 
     @Test
     public void testSha3() {
-        Assume.assumeTrue("SHA3 not supported", runtime().getVMConfig().sha3ImplCompress != 0L);
+        // Starting with JDK 21.0.13 (see JDK-8387330), HotSpot provides SHA3 C++ stubs on
+        // AMD64, so useSHA3Intrinsics() returns true. However, this test compiles
+        // implCompress0 as a Graal intrinsic, which requires a Graal LIR emitter for the
+        // target architecture. SHA3 only has a LIR emitter for AArch64
+        // (AArch64LIRGenerator.emitSha3ImplCompress), not AMD64, so we must also check
+        // SHA3Node.isSupported(arch).
+        //
+        // This does not affect correctness at runtime: on unsupported architectures,
+        // implCompress0 is added to UnimplementedGraalIntrinsics' ignore list and Graal
+        // compiles it as a regular method call. The HotSpot C++ stubs are still used by
+        // DigestBaseSnippets for the multi-block path.
+        Assume.assumeTrue("SHA3 not supported", runtime().getVMConfig().useSHA3Intrinsics() && MessageDigestNode.SHA3Node.isSupported(getArchitecture()));
         testWithInstalledIntrinsic("sun.security.provider.SHA3", "implCompress0", "testDigest", "SHA3-512", getData());
     }
 

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/meta/UnimplementedGraalIntrinsics.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/meta/UnimplementedGraalIntrinsics.java
@@ -454,6 +454,16 @@ public final class UnimplementedGraalIntrinsics {
                         "sun/security/provider/ML_DSA.implDilithiumNttMult([I[I[I)I",
                         "sun/security/provider/SHA3Parallel.doubleKeccak([J[J)I");
 
+        // JDK-8349721
+        add(toBeInvestigated,
+                        "com/sun/crypto/provider/ML_KEM.implKyber12To16([BI[SI)I",
+                        "com/sun/crypto/provider/ML_KEM.implKyberAddPoly([S[S[S)I",
+                        "com/sun/crypto/provider/ML_KEM.implKyberAddPoly([S[S[S[S)I",
+                        "com/sun/crypto/provider/ML_KEM.implKyberBarrettReduce([S)I",
+                        "com/sun/crypto/provider/ML_KEM.implKyberInverseNtt([S[S)I",
+                        "com/sun/crypto/provider/ML_KEM.implKyberNtt([S[S)I",
+                        "com/sun/crypto/provider/ML_KEM.implKyberNttMult([S[S[S[S)I");
+
         // These are known to be implemented down stream
         add(enterprise, // @formatter:off
                         "java/lang/Integer.toString(I)Ljava/lang/String;",

--- a/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/meta/UnimplementedGraalIntrinsics.java
+++ b/compiler/src/jdk.internal.vm.compiler/src/org/graalvm/compiler/hotspot/meta/UnimplementedGraalIntrinsics.java
@@ -445,6 +445,15 @@ public final class UnimplementedGraalIntrinsics {
             }
         }
 
+        // JDK-8348561
+        add(toBeInvestigated,
+                        "sun/security/provider/ML_DSA.implDilithiumAlmostInverseNtt([I[I)I",
+                        "sun/security/provider/ML_DSA.implDilithiumAlmostNtt([I[I)I",
+                        "sun/security/provider/ML_DSA.implDilithiumDecomposePoly([I[I[III)I",
+                        "sun/security/provider/ML_DSA.implDilithiumMontMulByConstant([II)I",
+                        "sun/security/provider/ML_DSA.implDilithiumNttMult([I[I[I)I",
+                        "sun/security/provider/SHA3Parallel.doubleKeccak([J[J)I");
+
         // These are known to be implemented down stream
         add(enterprise, // @formatter:off
                         "java/lang/Integer.toString(I)Ljava/lang/String;",


### PR DESCRIPTION
Add `ML_KEM` intrinsics from JDK-8349721 to
UnimplementedGraalIntrinsics as `toBeInvestigated` to work around the compilation issues.

Add `ML_DSA` and `SHA3Parallel` intrinsics from JDK-8348561 to UnimplementedGraalIntrinsics as `toBeInvestigated` to work around the compilation issues.

Fix `testSha3` to also check `SHA3Node.isSupported(arch)`. JDK 21.0.13 (JDK-8387330) adds SHA3 C++ stubs on AMD64, making `useSHA3Intrinsics()` return true, but Graal only has a SHA3 LIR emitter for AArch64. `implCompress0` falls back to a regular method call on AMD64.

>[!WARNING]
> This doesn't implement the said intrinsics, it just fixes the `mx gate` errors.



Closes https://github.com/graalvm/graalvm-community-jdk21u/issues/330
