### PR TITLE
[GR-50815] Enforce that DT_TEXTREL is not used

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -415,9 +415,6 @@ public class SubstrateOptions {
     @Option(help = "Enable support for threads and and thread-local variables (disable for single-threaded implementation)")//
     public static final HostedOptionKey<Boolean> MultiThreaded = new HostedOptionKey<>(true);
 
-    @Option(help = "Use only a writable native image heap (requires ld.gold linker)")//
-    public static final HostedOptionKey<Boolean> ForceNoROSectionRelocations = new HostedOptionKey<>(false);
-
     @Option(help = "Support multiple isolates.") //
     public static final HostedOptionKey<Boolean> SpawnIsolates = new HostedOptionKey<>(true);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractCommittedMemoryProvider.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractCommittedMemoryProvider.java
@@ -57,24 +57,21 @@ public abstract class AbstractCommittedMemoryProvider implements CommittedMemory
         if (Heap.getHeap().getImageHeapOffsetInAddressSpace() != 0) {
             return CEntryPointErrors.MAP_HEAP_FAILED;
         }
-        if (!SubstrateOptions.ForceNoROSectionRelocations.getValue()) {
-            /*
-             * Set strict read-only and read+write permissions for the image heap (the entire image
-             * heap should already be read-only, but the linker/loader can place it in a segment
-             * that has the executable bit set unnecessarily)
-             *
-             * If ForceNoROSectionRelocations is set, however, the image heap is writable and should
-             * remain so.
-             */
-            UnsignedWord heapSize = IMAGE_HEAP_END.get().subtract(heapBegin);
-            if (VirtualMemoryProvider.get().protect(heapBegin, heapSize, VirtualMemoryProvider.Access.READ) != 0) {
-                return CEntryPointErrors.PROTECT_HEAP_FAILED;
-            }
-            Pointer writableBegin = IMAGE_HEAP_WRITABLE_BEGIN.get();
-            UnsignedWord writableSize = IMAGE_HEAP_WRITABLE_END.get().subtract(writableBegin);
-            if (VirtualMemoryProvider.get().protect(writableBegin, writableSize, VirtualMemoryProvider.Access.READ | VirtualMemoryProvider.Access.WRITE) != 0) {
-                return CEntryPointErrors.PROTECT_HEAP_FAILED;
-            }
+
+        /*
+         * Set strict read-only and read+write permissions for the image heap (the entire image heap
+         * should already be read-only, but the linker/loader can place it in a segment that has the
+         * executable bit set unnecessarily)
+         */
+        UnsignedWord heapSize = IMAGE_HEAP_END.get().subtract(heapBegin);
+        if (VirtualMemoryProvider.get().protect(heapBegin, heapSize, VirtualMemoryProvider.Access.READ) != 0) {
+            return CEntryPointErrors.PROTECT_HEAP_FAILED;
+        }
+
+        Pointer writableBegin = IMAGE_HEAP_WRITABLE_BEGIN.get();
+        UnsignedWord writableSize = IMAGE_HEAP_WRITABLE_END.get().subtract(writableBegin);
+        if (VirtualMemoryProvider.get().protect(writableBegin, writableSize, VirtualMemoryProvider.Access.READ | VirtualMemoryProvider.Access.WRITE) != 0) {
+            return CEntryPointErrors.PROTECT_HEAP_FAILED;
         }
 
         return CEntryPointErrors.NO_ERROR;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,6 +258,14 @@ public abstract class CCLinkerInvocation implements LinkerInvocation {
             super(imageKind, nativeLibs, symbols);
             additionalPreOptions.add("-z");
             additionalPreOptions.add("noexecstack");
+
+            /*
+             * This is needed if the default linker is ld.lld from LLVM. On the GNU linker this
+             * option is the default, so we can just set it unconditionally.
+             */
+            additionalPreOptions.add("-z");
+            additionalPreOptions.add("notext");
+
             if (SubstrateOptions.ForceNoROSectionRelocations.getValue()) {
                 additionalPreOptions.add("-fuse-ld=gold");
                 additionalPreOptions.add("-Wl,--rosegment");

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java
@@ -60,6 +60,8 @@ import com.oracle.svm.hosted.c.codegen.CCompilerInvoker;
 import com.oracle.svm.hosted.c.libc.HostedLibCBase;
 import com.oracle.svm.hosted.jdk.JNIRegistrationSupport;
 
+import static com.oracle.svm.core.SubstrateOptions.SpawnIsolates;
+
 public abstract class CCLinkerInvocation implements LinkerInvocation {
 
     protected CCLinkerInvocation(AbstractImage.NativeImageKind imageKind, NativeLibraries nativeLibs, List<ObjectFile.Symbol> imageSymbols) {
@@ -259,17 +261,11 @@ public abstract class CCLinkerInvocation implements LinkerInvocation {
             additionalPreOptions.add("-z");
             additionalPreOptions.add("noexecstack");
 
-            /*
-             * This is needed if the default linker is ld.lld from LLVM. On the GNU linker this
-             * option is the default, so we can just set it unconditionally.
-             */
+            // The linker should fail if DT_TEXTREL is needed, otherwise the image won't work on
+            // SELinux. If SpawnIsolates are disabled, this won't work as dynamic relocations
+            // are needed for heap access.
             additionalPreOptions.add("-z");
-            additionalPreOptions.add("notext");
-
-            if (SubstrateOptions.ForceNoROSectionRelocations.getValue()) {
-                additionalPreOptions.add("-fuse-ld=gold");
-                additionalPreOptions.add("-Wl,--rosegment");
-            }
+            additionalPreOptions.add(SpawnIsolates.getValue() ? "text" : "notext");
 
             if (SubstrateOptions.RemoveUnusedSymbols.getValue()) {
                 /* Perform garbage collection of unused input sections. */

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImage.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.hosted.image;
 
+import static com.oracle.svm.core.SubstrateOptions.SpawnIsolates;
 import static com.oracle.svm.core.SubstrateUtil.mangleName;
 import static com.oracle.svm.core.util.VMError.shouldNotReachHere;
 
@@ -427,12 +428,10 @@ public abstract class NativeImage extends AbstractImage {
             final NativeTextSectionImpl textImpl = NativeTextSectionImpl.factory(textBuffer, objectFile, codeCache);
             textSection = objectFile.newProgbitsSection(SectionName.TEXT.getFormatDependentName(objectFile.getFormat()), objectFile.getPageSize(), false, true, textImpl);
 
-            boolean writable = SubstrateOptions.ForceNoROSectionRelocations.getValue();
-
             // Read-only data section
             final RelocatableBuffer roDataBuffer = new RelocatableBuffer(roSectionSize, objectFile.getByteOrder());
             final ProgbitsSectionImpl roDataImpl = new BasicProgbitsSectionImpl(roDataBuffer.getBackingArray());
-            roDataSection = objectFile.newProgbitsSection(SectionName.RODATA.getFormatDependentName(objectFile.getFormat()), objectFile.getPageSize(), writable, false, roDataImpl);
+            roDataSection = objectFile.newProgbitsSection(SectionName.RODATA.getFormatDependentName(objectFile.getFormat()), objectFile.getPageSize(), false, false, roDataImpl);
 
             // Read-write data section
             final RelocatableBuffer rwDataBuffer = new RelocatableBuffer(rwSectionSize, objectFile.getByteOrder());
@@ -462,13 +461,19 @@ public abstract class NativeImage extends AbstractImage {
             // Dynamic linkers/loaders generally don't ensure any alignment to more than page
             // boundaries, so we take care of this ourselves in CommittedMemoryProvider, if we can.
             int alignment = objectFile.getPageSize();
-            RelocatableBuffer heapSectionBuffer = new RelocatableBuffer(imageHeapSize, objectFile.getByteOrder());
+
+            // Manually add padding to the SVM_HEAP section, because when SpawnIsolates are disabled
+            // we operate with mprotect on it with page size granularity.
+            long paddedImageHeapSize = SpawnIsolates.getValue() ? imageHeapSize : NumUtil.roundUp(imageHeapSize, alignment);
+            RelocatableBuffer heapSectionBuffer = new RelocatableBuffer(paddedImageHeapSize, objectFile.getByteOrder());
+
             ProgbitsSectionImpl heapSectionImpl = new BasicProgbitsSectionImpl(heapSectionBuffer.getBackingArray());
-            heapSection = objectFile.newProgbitsSection(SectionName.SVM_HEAP.getFormatDependentName(objectFile.getFormat()), alignment, writable, false, heapSectionImpl);
+            // Note: On isolate startup the read only part of the heap will be set up as such.
+            heapSection = objectFile.newProgbitsSection(SectionName.SVM_HEAP.getFormatDependentName(objectFile.getFormat()), alignment, true, false, heapSectionImpl);
             objectFile.createDefinedSymbol(heapSection.getName(), heapSection, 0, 0, false, false);
 
             long offsetOfARelocatablePointer = writer.writeHeap(debug, heapSectionBuffer);
-            assert !SubstrateOptions.SpawnIsolates.getValue() || heapSectionBuffer.getByteBuffer().getLong((int) offsetOfARelocatablePointer) == 0L;
+            assert !SpawnIsolates.getValue() || heapSectionBuffer.getByteBuffer().getLong((int) offsetOfARelocatablePointer) == 0L;
 
             defineDataSymbol(Isolates.IMAGE_HEAP_BEGIN_SYMBOL_NAME, heapSection, 0);
             defineDataSymbol(Isolates.IMAGE_HEAP_END_SYMBOL_NAME, heapSection, imageHeapSize);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageViaCC.java
@@ -71,10 +71,6 @@ public abstract class NativeImageViaCC extends NativeImage {
             potentialCauses.add("Native Image is using a linker that appears to be incompatible with the tool chain used to build the JDK static libraries. " +
                             "The latter is typically shown in the output of `java -Xinternalversion`.");
         }
-        if (SubstrateOptions.ForceNoROSectionRelocations.getValue() && (linkerOutput.contains("fatal error: cannot find ") ||
-                        linkerOutput.contains("error: invalid linker name in argument"))) {
-            potentialCauses.add(SubstrateOptions.ForceNoROSectionRelocations.getName() + " option cannot be used if ld.gold linker is missing from the host system");
-        }
 
         Pattern p = Pattern.compile(".*cannot find -l([^\\s]+)\\s.*", Pattern.DOTALL);
         Matcher m = p.matcher(linkerOutput);


### PR DESCRIPTION
<!--
  Please use the following template for Backport PRs

  Make sure to use `git cherry-pick -x` when cherry picking the commits to backport.

  Reference the upstream pull requests being backported, e.g. https://github.com/oracle/graal/pull/9836
  if not upstream pull requests exists, then reference the upstream commit directly,
  e.g. https://github.com/oracle/graal/commit/6e859d90dde01a23e6973e25984419f29edc9c2b

  Example:

  This PR backports:
  - https://github.com/oracle/graal/pull/7427
  - part of https://github.com/oracle/graal/pull/10864
-->
**This PR backports:**
- https://github.com/oracle/graal/pull/7469 (as a dependency for a clean backport)
- https://github.com/oracle/graal/pull/8768

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 
  - minor conflict due to `sectionOffsetOfARelocatablePointer` being named `offsetOfARelocatablePointer` in jdk21u. Kept `offsetOfARelocatablePointer` as the least intrusive change.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk21u/issues/334
